### PR TITLE
Works around SPI documentation bug

### DIFF
--- a/Sources/TecoSigner/Documentation.docc/index.md
+++ b/Sources/TecoSigner/Documentation.docc/index.md
@@ -1,9 +1,5 @@
 #  ``TecoSigner``
 
-@Metadata {
-    @DisplayName("Teco Signer")
-}
-
 Signing helpers for Tencent Cloud API signature V3.
 
 ## Overview


### PR DESCRIPTION
Removes custom documentation display name until SwiftPackageIndex/SwiftPackageIndex-Server#2249 is fixed.