### PR TITLE
Uses lowercased HTTP header names

### DIFF
--- a/Sources/TecoCore/Transport/TCRequest.swift
+++ b/Sources/TecoCore/Transport/TCRequest.swift
@@ -124,13 +124,13 @@ extension TCRequest {
 
     /// Add common header parameters to all requests: "Action", "Version", "Region" and "Language".
     private mutating func addCommonParameters(action: String, configuration: TCServiceConfig) {
-        httpHeaders.replaceOrAdd(name: "X-TC-Action", value: action)
-        httpHeaders.replaceOrAdd(name: "X-TC-Version", value: configuration.version)
+        httpHeaders.replaceOrAdd(name: "x-tc-action", value: action)
+        httpHeaders.replaceOrAdd(name: "x-tc-version", value: configuration.version)
         if let region = self.region {
-            httpHeaders.replaceOrAdd(name: "X-TC-Region", value: region.rawValue)
+            httpHeaders.replaceOrAdd(name: "x-tc-region", value: region.rawValue)
         }
         if let language = configuration.language {
-            httpHeaders.replaceOrAdd(name: "X-TC-Language", value: language.rawValue)
+            httpHeaders.replaceOrAdd(name: "x-tc-language", value: language.rawValue)
         }
     }
 

--- a/Sources/TecoSigner/Documentation.docc/Guides/SignRequests.md
+++ b/Sources/TecoSigner/Documentation.docc/Guides/SignRequests.md
@@ -52,10 +52,10 @@ Supply required HTTP headers, which must include `Content-Type`. Common paramete
 
 ```swift
 let headers: HTTPHeaders = [
-    "Content-Type": "application/json",
-    "X-TC-Action": "DescribeInstances",
-    "X-TC-Version": "2017-03-12",
-    "X-TC-Region": "ap-guangzhou",
+    "content-type": "application/json",
+    "x-tc-action": "DescribeInstances",
+    "x-tc-version": "2017-03-12",
+    "x-tc-region": "ap-guangzhou",
 ]
 ```
 
@@ -80,10 +80,10 @@ let signedHeadersForGETRequest = signer.signHeaders(
     url: URL(string: "https://cvm.tencentcloudapi.com/?Limit=10&Offset=10")!,
     method: .GET,
     headers: [
-        "Content-Type": "application/x-www-form-urlencoded",
-        "X-TC-Action": "DescribeInstances",
-        "X-TC-Version": "2017-03-12",
-        "X-TC-Region": "ap-guangzhou",
+        "content-type": "application/x-www-form-urlencoded",
+        "x-tc-action": "DescribeInstances",
+        "x-tc-version": "2017-03-12",
+        "x-tc-region": "ap-guangzhou",
     ],
     date: Date(timeIntervalSinceNow: -10)
 )

--- a/Sources/TecoSigner/signer.swift
+++ b/Sources/TecoSigner/signer.swift
@@ -287,8 +287,8 @@ public struct TCSigner: _SignerSendable {
         }
 
         return headersToSign
-            .sorted { $0.name < $1.name }
             .map { ($0.name.lowercased(), $0.value.trimmingCharacters(in: .whitespaces).lowercased()) }
+            .sorted { $0.name < $1.name }
     }
 
     /// returns port from URL. If port is set to 80 on an http url or 443 on an https url nil is returned

--- a/Sources/TecoSigner/signer.swift
+++ b/Sources/TecoSigner/signer.swift
@@ -132,20 +132,20 @@ public struct TCSigner: _SignerSendable {
         let dateString = TCSigner.dateString(date)
         var headers = headers
         // add timestamp, host and body hash to headers
-        headers.replaceOrAdd(name: "Host", value: Self.hostname(from: url))
-        headers.replaceOrAdd(name: "X-TC-RequestClient", value: "Teco")
-        headers.replaceOrAdd(name: "X-TC-Timestamp", value: timestamp)
-        headers.replaceOrAdd(name: "X-TC-Content-SHA256", value: bodyHash)
+        headers.replaceOrAdd(name: "host", value: Self.hostname(from: url))
+        headers.replaceOrAdd(name: "x-tc-requestclient", value: "Teco")
+        headers.replaceOrAdd(name: "x-tc-timestamp", value: timestamp)
+        headers.replaceOrAdd(name: "x-tc-content-sha256", value: bodyHash)
 
         // set authorization to SKIP without actually signing if requested
         if mode == .skip {
-            headers.replaceOrAdd(name: "Authorization", value: "SKIP")
+            headers.replaceOrAdd(name: "authorization", value: "SKIP")
             return headers
         }
 
         // add session token if available
         if !omitSessionToken, let sessionToken = credential.token {
-            headers.replaceOrAdd(name: "X-TC-Token", value: sessionToken)
+            headers.replaceOrAdd(name: "x-tc-token", value: sessionToken)
         }
 
         // construct signing data. Do this after adding the headers as it uses data from the headers
@@ -158,11 +158,11 @@ public struct TCSigner: _SignerSendable {
         "Signature=\(signature(signingData: signingData))"
 
         // add Authorization header
-        headers.replaceOrAdd(name: "Authorization", value: authorization)
+        headers.replaceOrAdd(name: "authorization", value: authorization)
 
         // now we have signed the request we can add the security token if required
         if omitSessionToken, let sessionToken = credential.token {
-            headers.replaceOrAdd(name: "X-TC-Token", value: sessionToken)
+            headers.replaceOrAdd(name: "x-tc-token", value: sessionToken)
         }
 
         return headers

--- a/Tests/TecoSignerTests/TCSignerTests.swift
+++ b/Tests/TecoSignerTests/TCSignerTests.swift
@@ -45,13 +45,13 @@ final class TCSignerTests: XCTestCase {
         let headers = signer.signHeaders(
             url: URL(string: "https://cvm.tencentcloudapi.com")!,
             method: .POST,
-            headers: ["Content-Type": "application/json"],
+            headers: ["content-type": "application/json"],
             body: .string("{}"),
             mode: .minimal,
             date: Date(timeIntervalSince1970: 1_000_000_000)
         )
         XCTAssertEqual(
-            headers["Authorization"].first,
+            headers["authorization"].first,
             "TC3-HMAC-SHA256 Credential=MY_TC_SECRET_ID/2001-09-09/cvm/tc3_request, SignedHeaders=content-type;host, Signature=2c0b761dcdeacac29ac9d135f9f22b0fa52d4536d8b7727a8a515935c47eaea7"
         )
     }
@@ -61,12 +61,12 @@ final class TCSignerTests: XCTestCase {
         let headers = signer.signHeaders(
             url: URL(string: "https://cvm.tencentcloudapi.com/?InstanceIds.0=ins-000000&InstanceIds.1=ins-000001")!,
             method: .GET,
-            headers: ["Content-Type": "application/x-www-form-urlencoded"],
+            headers: ["content-type": "application/x-www-form-urlencoded"],
             mode: .minimal,
             date: Date(timeIntervalSince1970: 1_000_000_000)
         )
         XCTAssertEqual(
-            headers["Authorization"].first,
+            headers["authorization"].first,
             "TC3-HMAC-SHA256 Credential=MY_TC_SECRET_ID/2001-09-09/cvm/tc3_request, SignedHeaders=content-type;host, Signature=a4315b91798a181a6e5fb0353590040a399edad4a003ef5688d71fb34366c471"
         )
     }
@@ -79,15 +79,15 @@ final class TCSignerTests: XCTestCase {
             url: URL(string: "https://region.tencentcloudapi.com")!,
             method: .POST,
             headers: [
-                "Content-Type": "application/json",
-                "X-TC-Action": "DescribeRegions",
-                "X-TC-Version": "2022-06-27",
+                "content-type": "application/json",
+                "x-tc-action": "DescribeRegions",
+                "x-tc-version": "2022-06-27",
             ],
             body: .string(#"{"Product":"cvm"}"#),
             date: Date(timeIntervalSince1970: 1_000_000_000)
         )
         XCTAssertEqual(
-            headers["Authorization"].first,
+            headers["authorization"].first,
             "TC3-HMAC-SHA256 Credential=MY_TC_SECRET_ID/2001-09-09/region/tc3_request, SignedHeaders=content-type;host;x-tc-action;x-tc-content-sha256;x-tc-requestclient;x-tc-timestamp;x-tc-version, Signature=2e9e6e2b803969ee22aa7297daa305cde69b30bc0720f3cf779cf69efa6f42cb"
         )
     }
@@ -98,14 +98,14 @@ final class TCSignerTests: XCTestCase {
             url: URL(string: "https://region.tencentcloudapi.com/?Product=cvm")!,
             method: .GET,
             headers: [
-                "Content-Type": "application/x-www-form-urlencoded",
-                "X-TC-Action": "DescribeRegions",
-                "X-TC-Version": "2022-06-27",
+                "content-type": "application/x-www-form-urlencoded",
+                "x-tc-action": "DescribeRegions",
+                "x-tc-version": "2022-06-27",
             ],
             date: Date(timeIntervalSince1970: 1_000_000_000)
         )
         XCTAssertEqual(
-            headers["Authorization"].first,
+            headers["authorization"].first,
             "TC3-HMAC-SHA256 Credential=MY_TC_SECRET_ID/2001-09-09/region/tc3_request, SignedHeaders=content-type;host;x-tc-action;x-tc-content-sha256;x-tc-requestclient;x-tc-timestamp;x-tc-version, Signature=96a261572b4f62ec92bd6f94e28dd772987d77927f937c94524f5a6a955cd7d5"
         )
     }
@@ -121,9 +121,9 @@ final class TCSignerTests: XCTestCase {
         let headers2 = signer.signHeaders(url: URL(string: "https://cvm.tencentcloudapi.com")!, method: .POST, body: .data(data), date: Date(timeIntervalSinceReferenceDate: 0))
         let headers3 = signer.signHeaders(url: URL(string: "https://cvm.tencentcloudapi.com")!, method: .POST, body: .byteBuffer(buffer), date: Date(timeIntervalSinceReferenceDate: 0))
 
-        XCTAssertNotNil(headers1["Authorization"].first)
-        XCTAssertEqual(headers1["Authorization"].first, headers2["Authorization"].first)
-        XCTAssertEqual(headers2["Authorization"].first, headers3["Authorization"].first)
+        XCTAssertNotNil(headers1["authorization"].first)
+        XCTAssertEqual(headers1["authorization"].first, headers2["authorization"].first)
+        XCTAssertEqual(headers2["authorization"].first, headers3["authorization"].first)
     }
 
     func testCanonicalRequest() throws {
@@ -132,7 +132,7 @@ final class TCSignerTests: XCTestCase {
         let signingData = TCSigner.SigningData(
             url: url,
             method: .POST,
-            headers: ["Content-Type": "application/json", "Host": "localhost", "User-Agent": "Teco Test"],
+            headers: ["content-type": "application/json", "host": "localhost", "User-Agent": "Teco Test"],
             body: .string("{}"),
             timestamp: TCSigner.timestamp(Date(timeIntervalSince1970: 234_873)),
             date: TCSigner.dateString(Date(timeIntervalSince1970: 234_873)),
@@ -157,11 +157,11 @@ final class TCSignerTests: XCTestCase {
         let headers = signer.signHeaders(
             url: URL(string: "https://cvm.tencentcloudapi.com/?InstanceIds.0=ins-000000")!,
             method: .GET,
-            headers: ["Content-Type": "application/x-www-form-urlencoded"],
+            headers: ["content-type": "application/x-www-form-urlencoded"],
             mode: .skip,
             date: Date(timeIntervalSince1970: 1_000_000_000)
         )
-        XCTAssertEqual(headers["Authorization"].first, "SKIP")
+        XCTAssertEqual(headers["authorization"].first, "SKIP")
     }
 
     // MARK: - Tencent Cloud Signer samples
@@ -171,19 +171,19 @@ final class TCSignerTests: XCTestCase {
         let signer = TCSigner(credential: tcSampleCredential, service: "cvm")
         let url = URL(string: "https://cvm.tencentcloudapi.com")!
         let headers: HTTPHeaders = [
-            "Content-Type": "application/json; charset=utf-8",
-            "Host": "cvm.tencentcloudapi.com",
-            "X-TC-Action": "DescribeInstances",
-            "X-TC-Timestamp": "1551113065",
-            "X-TC-Version": "2017-03-12",
-            "X-TC-Region": "ap-guangzhou",
+            "content-type": "application/json; charset=utf-8",
+            "host": "cvm.tencentcloudapi.com",
+            "x-tc-action": "DescribeInstances",
+            "x-tc-timestamp": "1551113065",
+            "x-tc-version": "2017-03-12",
+            "x-tc-region": "ap-guangzhou",
         ]
         let body: TCSigner.BodyData = .string(#"{"Limit": 1, "Filters": [{"Values": ["\u672a\u547d\u540d"], "Name": "instance-name"}]}"#)
         let signedHeaders = signer.signHeaders(
             url: url, method: .POST, headers: headers, body: body, mode: .minimal, date: tcSampleDate
         )
         XCTAssertEqual(
-            signedHeaders["Authorization"].first,
+            signedHeaders["authorization"].first,
             "TC3-HMAC-SHA256 Credential=AKIDz8krbsJ5yKBZQpn74WFkmLPx3EXAMPLE/2019-02-25/cvm/tc3_request, SignedHeaders=content-type;host, Signature=72e494ea809ad7a8c8f7a4507b9bddcbaa8e581f516e8da2f66e2c5a96525168"
         )
     }

--- a/Tests/TecoSignerTests/TCSignerTests.swift
+++ b/Tests/TecoSignerTests/TCSignerTests.swift
@@ -126,6 +126,25 @@ final class TCSignerTests: XCTestCase {
         XCTAssertEqual(headers2["authorization"].first, headers3["authorization"].first)
     }
 
+    func testUppercasedHeaderName() {
+        let signer = TCSigner(credential: credential, service: "region")
+        let headers = signer.signHeaders(
+            url: URL(string: "https://region.tencentcloudapi.com")!,
+            method: .POST,
+            headers: [
+                "Content-Type": "application/json",
+                "X-TC-ACTION": "DescribeRegions",
+                "X-TC-VERSION": "2022-06-27",
+            ],
+            body: .string(#"{"Product":"cvm"}"#),
+            date: Date(timeIntervalSince1970: 1_000_000_000)
+        )
+        XCTAssertEqual(
+            headers["Authorization"].first,
+            "TC3-HMAC-SHA256 Credential=MY_TC_SECRET_ID/2001-09-09/region/tc3_request, SignedHeaders=content-type;host;x-tc-action;x-tc-content-sha256;x-tc-requestclient;x-tc-timestamp;x-tc-version, Signature=2e9e6e2b803969ee22aa7297daa305cde69b30bc0720f3cf779cf69efa6f42cb"
+        )
+    }
+
     func testCanonicalRequest() throws {
         let url = URL(string: "https://test.com/?hello=true&item=apple")!
         let signer = TCSigner(credential: credential, service: "sns")


### PR DESCRIPTION
This is the recommended pattern and also makes the library HTTP2-compatible.