### PR TITLE
Updates `TecoSendable` to be pure underscored type alias

### DIFF
--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -43,7 +43,7 @@ import TecoSigner
 /// This is the workhorse of TecoCore. You provide it with a ``TCRequestModel``, it converts it to `TCRequest` which is then converted to a raw `HTTPClient` request. This is then sent to Tencent Cloud.
 ///
 /// When the response from Tencent Cloud is received, it will be converted to a `TCResponse`, which is then decoded to generate a ``TCResponseModel`` or to create and throw a ``TCErrorType``.
-public final class TCClient: TecoSendable {
+public final class TCClient: _TecoSendable {
     // MARK: Member variables
 
     private static let globalRequestID = ManagedAtomic<Int>(0)
@@ -191,7 +191,7 @@ public final class TCClient: TecoSendable {
     }
 
     /// Specifies how `HTTPClient` will be created and establishes lifecycle ownership.
-    public enum HTTPClientProvider: TecoSendable {
+    public enum HTTPClientProvider: _TecoSendable {
         /// Use `HTTPClient` provided by the user.
         ///
         /// The user should be responsible for the lifecycle of the `HTTPClient`.
@@ -207,7 +207,7 @@ public final class TCClient: TecoSendable {
     }
 
     /// Additional options.
-    public struct Options: TecoSendable {
+    public struct Options: _TecoSendable {
         /// Log level used for request logging.
         let requestLogLevel: Logger.Level
         /// Log level used for error logging

--- a/Sources/TecoCore/Common/TCModel.swift
+++ b/Sources/TecoCore/Common/TCModel.swift
@@ -14,7 +14,7 @@
 /// Protocol for the input and output data objects for all Tencent Cloud service commands.
 ///
 /// The model must be codable in both directions.
-public protocol TCModel: TecoSendable, Codable {}
+public protocol TCModel: Codable, _TecoSendable {}
 
 /// ``TCModel`` that can be used in API input.
 ///

--- a/Sources/TecoCore/Common/TCService.swift
+++ b/Sources/TecoCore/Common/TCService.swift
@@ -31,7 +31,7 @@ import NIOHTTP1
 /// Tencent Cloud service client protocol.
 ///
 /// Contains a client to communicate with Tencent Cloud and configuration for defining how to communicate.
-public protocol TCService: TecoSendable {
+public protocol TCService: _TecoSendable {
     /// Client used to communicate with Tencent Cloud.
     var client: TCClient { get }
     /// Service context details.

--- a/Sources/TecoCore/Credential/CredentialProvider.swift
+++ b/Sources/TecoCore/Credential/CredentialProvider.swift
@@ -28,7 +28,7 @@ import NIOCore
 import TecoSigner
 
 /// Provider for Tencent Cloud credentials.
-public protocol CredentialProvider: TecoSendable, CustomStringConvertible {
+public protocol CredentialProvider: CustomStringConvertible, _TecoSendable {
     /// Provide a credential.
     ///
     /// - Parameters:

--- a/Sources/TecoCore/Credential/OIDCRoleArnCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/OIDCRoleArnCredentialProvider.swift
@@ -75,7 +75,7 @@ private struct STSAssumeRoleWithWebIdentityResponse: TCResponseModel {
 }
 
 /// Credential provider that returns temporary credentials acquired with OIDC.
-struct OIDCRoleArnCredentialProvider: CredentialProviderWithClient {
+struct OIDCRoleArnCredentialProvider: CredentialProviderWithClient, NIOPreconcurrencySendable {
     let client: TCClient
 
     private let config: TCServiceConfig

--- a/Sources/TecoCore/Utils/Sendable.swift
+++ b/Sources/TecoCore/Utils/Sendable.swift
@@ -11,9 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-#if swift(>=5.6)
-@preconcurrency public protocol TecoSendable: Sendable {}
+#if compiler(>=5.6)
+public typealias _TecoSendable = Sendable
 #else
-public protocol TecoSendable {}
+public typealias _TecoSendable = Any
 #endif


### PR DESCRIPTION
This avoids `TecoSendable` becoming a concrete protocol since no clients are actually using it.