### PR TITLE
Redesigns `TCSigner` API interface

### DIFF
--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -346,7 +346,7 @@ extension TCClient {
     /// Generate signed headers.
     ///
     /// - Parameters:
-    ///    - url : URL to sign.
+    ///    - url : URL to sign (RFC 3986).
     ///    - httpMethod: HTTP method to use (`.GET` or `.POST`).
     ///    - httpHeaders: Headers that are to be sent with this URL.
     ///    - body: Payload to sign.
@@ -369,11 +369,8 @@ extension TCClient {
             service: serviceConfig.service
         )
         return createSigner(serviceConfig: serviceConfig, logger: logger).flatMapThrowing { signer in
-            guard let cleanURL = signer.processURL(url: url) else {
-                throw TCClient.ClientError.invalidURL
-            }
             let body: TCSigner.BodyData? = body.asByteBuffer().map { .byteBuffer($0) }
-            return signer.signHeaders(url: cleanURL, method: httpMethod, headers: headers, body: body)
+            return signer.signHeaders(url: url, method: httpMethod, headers: headers, body: body)
         }
     }
 

--- a/Sources/TecoSigner/signer.swift
+++ b/Sources/TecoSigner/signer.swift
@@ -110,6 +110,32 @@ public struct TCSigner: _SignerSendable {
     /// Generate signed headers, for an HTTP request.
     ///
     /// - Parameters:
+    ///   - url: Request URL string.
+    ///   - method: Request HTTP method.
+    ///   - headers: Request headers.
+    ///   - body: Request body.
+    ///   - mode: Signing mode.
+    ///   - omitSecurityToken: Should we include security token in the canonical headers.
+    ///   - date: Date that URL is valid from, defaults to now.
+    /// - Returns: Request headers with added "Authorization" header that contains request signature.
+    public func signHeaders(
+        url: String,
+        method: HTTPMethod = .POST,
+        headers: HTTPHeaders = HTTPHeaders(),
+        body: BodyData? = nil,
+        mode: SigningMode = .default,
+        omitSessionToken: Bool = false,
+        date: Date = Date()
+    ) throws -> HTTPHeaders {
+        guard let url = URL(string: url) else {
+            throw TCSignerError.invalidURL
+        }
+        return self.signHeaders(url: url, method: method, headers: headers, body: body, mode: mode, omitSessionToken: omitSessionToken, date: date)
+    }
+
+    /// Generate signed headers, for an HTTP request.
+    ///
+    /// - Parameters:
     ///   - url: Request URL.
     ///   - method: Request HTTP method.
     ///   - headers: Request headers.
@@ -167,7 +193,13 @@ public struct TCSigner: _SignerSendable {
 
         return headers
     }
+}
 
+enum TCSignerError: Error {
+    case invalidURL
+}
+
+extension TCSigner {
     /// structure used to store data used throughout the signing process
     struct SigningData {
         let url: URL

--- a/Sources/TecoSigner/signer.swift
+++ b/Sources/TecoSigner/signer.swift
@@ -234,8 +234,8 @@ extension TCSigner {
             .map { "\($0.name):\($0.value)\n" }
             .joined()
         let canonicalRequest = "\(signingData.method.rawValue)\n" +
-            "/\n" +
-            "\(signingData.unsignedURL.query ?? "")\n" + // assuming query parameters have are already percent encoded correctly
+            "\(signingData.unsignedURL.canonicalURI)\n" +
+            "\(signingData.unsignedURL.canonicalQuery)\n" +
             "\(canonicalHeaders)\n" +
             "\(signingData.signedHeaders)\n" +
             signingData.hashedPayload
@@ -316,6 +316,17 @@ extension TCSigner {
 
     private static func hostname(from url: URL) -> String {
         "\(url.host ?? "")\(port(from: url).map { ":\($0)" } ?? "")"
+    }
+}
+
+extension URL {
+    var canonicalURI: String {
+        let path = self.path
+        return path.isEmpty ? "/" : path
+    }
+    var canonicalQuery: String {
+        // assuming query parameters are already percent encoded correctly
+        return self.query ?? ""
     }
 }
 

--- a/Tests/TecoSignerTests/TCSignerTests.swift
+++ b/Tests/TecoSignerTests/TCSignerTests.swift
@@ -40,10 +40,10 @@ final class TCSignerTests: XCTestCase {
 
     // - MARK: Minimal signing by API Explorer - https://console.cloud.tencent.com/api/explorer
 
-    func testMinimalSignPostRequest() {
+    func testMinimalSignPostRequest() throws {
         let signer = TCSigner(credential: credential, service: "cvm")
-        let headers = signer.signHeaders(
-            url: URL(string: "https://cvm.tencentcloudapi.com")!,
+        let headers = try signer.signHeaders(
+            url: "https://cvm.tencentcloudapi.com",
             method: .POST,
             headers: ["content-type": "application/json"],
             body: .string("{}"),
@@ -56,10 +56,10 @@ final class TCSignerTests: XCTestCase {
         )
     }
 
-    func testMinimalSignGetRequest() {
+    func testMinimalSignGetRequest() throws {
         let signer = TCSigner(credential: credential, service: "cvm")
-        let headers = signer.signHeaders(
-            url: URL(string: "https://cvm.tencentcloudapi.com/?InstanceIds.0=ins-000000&InstanceIds.1=ins-000001")!,
+        let headers = try signer.signHeaders(
+            url: "https://cvm.tencentcloudapi.com/?InstanceIds.0=ins-000000&InstanceIds.1=ins-000001",
             method: .GET,
             headers: ["content-type": "application/x-www-form-urlencoded"],
             mode: .minimal,
@@ -73,10 +73,10 @@ final class TCSignerTests: XCTestCase {
 
     // - MARK: Extended Signing
 
-    func testSignPostRequest() {
+    func testSignPostRequest() throws {
         let signer = TCSigner(credential: credential, service: "region")
-        let headers = signer.signHeaders(
-            url: URL(string: "https://region.tencentcloudapi.com")!,
+        let headers = try signer.signHeaders(
+            url: "https://region.tencentcloudapi.com",
             method: .POST,
             headers: [
                 "content-type": "application/json",
@@ -92,10 +92,10 @@ final class TCSignerTests: XCTestCase {
         )
     }
 
-    func testSignGetRequest() {
+    func testSignGetRequest() throws {
         let signer = TCSigner(credential: credential, service: "region")
-        let headers = signer.signHeaders(
-            url: URL(string: "https://region.tencentcloudapi.com/?Product=cvm")!,
+        let headers = try signer.signHeaders(
+            url: "https://region.tencentcloudapi.com/?Product=cvm",
             method: .GET,
             headers: [
                 "content-type": "application/x-www-form-urlencoded",
@@ -110,26 +110,26 @@ final class TCSignerTests: XCTestCase {
         )
     }
 
-    func testBodyData() {
+    func testBodyData() throws {
         let string = "testing, testing, 1,2,1,2"
         let data = string.data(using: .utf8)!
         var buffer = ByteBufferAllocator().buffer(capacity: data.count)
         buffer.writeBytes(data)
 
         let signer = TCSigner(credential: credential, service: "cvm")
-        let headers1 = signer.signHeaders(url: URL(string: "https://cvm.tencentcloudapi.com")!, method: .POST, body: .string(string), date: Date(timeIntervalSinceReferenceDate: 0))
-        let headers2 = signer.signHeaders(url: URL(string: "https://cvm.tencentcloudapi.com")!, method: .POST, body: .data(data), date: Date(timeIntervalSinceReferenceDate: 0))
-        let headers3 = signer.signHeaders(url: URL(string: "https://cvm.tencentcloudapi.com")!, method: .POST, body: .byteBuffer(buffer), date: Date(timeIntervalSinceReferenceDate: 0))
+        let headers1 = try signer.signHeaders(url: "https://cvm.tencentcloudapi.com", method: .POST, body: .string(string), date: Date(timeIntervalSinceReferenceDate: 0))
+        let headers2 = try signer.signHeaders(url: "https://cvm.tencentcloudapi.com", method: .POST, body: .data(data), date: Date(timeIntervalSinceReferenceDate: 0))
+        let headers3 = try signer.signHeaders(url: "https://cvm.tencentcloudapi.com", method: .POST, body: .byteBuffer(buffer), date: Date(timeIntervalSinceReferenceDate: 0))
 
         XCTAssertNotNil(headers1["authorization"].first)
         XCTAssertEqual(headers1["authorization"].first, headers2["authorization"].first)
         XCTAssertEqual(headers2["authorization"].first, headers3["authorization"].first)
     }
 
-    func testUppercasedHeaderName() {
+    func testUppercasedHeaderName() throws {
         let signer = TCSigner(credential: credential, service: "region")
-        let headers = signer.signHeaders(
-            url: URL(string: "https://region.tencentcloudapi.com")!,
+        let headers = try signer.signHeaders(
+            url: "https://region.tencentcloudapi.com",
             method: .POST,
             headers: [
                 "Content-Type": "application/json",
@@ -171,10 +171,10 @@ final class TCSignerTests: XCTestCase {
         XCTAssertEqual(request, expectedRequest)
     }
 
-    func testSkipAuthorization() {
+    func testSkipAuthorization() throws {
         let signer = TCSigner(credential: credential, service: "cvm")
-        let headers = signer.signHeaders(
-            url: URL(string: "https://cvm.tencentcloudapi.com/?InstanceIds.0=ins-000000")!,
+        let headers = try signer.signHeaders(
+            url: "https://cvm.tencentcloudapi.com/?InstanceIds.0=ins-000000",
             method: .GET,
             headers: ["content-type": "application/x-www-form-urlencoded"],
             mode: .skip,
@@ -186,7 +186,7 @@ final class TCSignerTests: XCTestCase {
     // MARK: - Tencent Cloud Signer samples
 
     // https://cloud.tencent.com/document/api/213/30654
-    func testTencentCloudSample() {
+    func testTencentCloudSample() throws {
         let signer = TCSigner(credential: tcSampleCredential, service: "cvm")
         let url = URL(string: "https://cvm.tencentcloudapi.com")!
         let headers: HTTPHeaders = [
@@ -198,9 +198,7 @@ final class TCSignerTests: XCTestCase {
             "x-tc-region": "ap-guangzhou",
         ]
         let body: TCSigner.BodyData = .string(#"{"Limit": 1, "Filters": [{"Values": ["\u672a\u547d\u540d"], "Name": "instance-name"}]}"#)
-        let signedHeaders = signer.signHeaders(
-            url: url, method: .POST, headers: headers, body: body, mode: .minimal, date: tcSampleDate
-        )
+        let signedHeaders = signer.signHeaders(url: url, method: .POST, headers: headers, body: body, mode: .minimal, date: tcSampleDate)
         XCTAssertEqual(
             signedHeaders["authorization"].first,
             "TC3-HMAC-SHA256 Credential=AKIDz8krbsJ5yKBZQpn74WFkmLPx3EXAMPLE/2019-02-25/cvm/tc3_request, SignedHeaders=content-type;host, Signature=72e494ea809ad7a8c8f7a4507b9bddcbaa8e581f516e8da2f66e2c5a96525168"


### PR DESCRIPTION
- Simplifies the implementation by deprecating `TCSigner.processURL(url:)` and making it no-op. The signer only expects the URL to be RFC3986 compatible.
- Adds a throwing `signHeader` function that takes a `String` as URL. This wraps over the original `URL` version, and will throw `TCSignerError.invalidURL` if the URL string is malformed.
- Avoids hardcoding request URI to be `/`. This should add to robustness and allow working with non-standard API endpoints.