### PR TITLE
Updates for latest SPI and DocC features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,3 +56,10 @@ jobs:
         run: swift build
       - name: Test
         run: swift test
+  build-with-docc:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: swift build -Xswiftc -DBUILDING_DOCC

--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,5 @@ version: 1
 builder:
   configs:
     - documentation_targets: [TecoCore, TecoPaginationHelpers, TecoSigner]
+      custom_documentation_parameters: ['--include-extended-types']
+      platform: linux

--- a/Sources/TecoCore/Common/RetryPolicy.swift
+++ b/Sources/TecoCore/Common/RetryPolicy.swift
@@ -25,6 +25,7 @@
 
 import AsyncHTTPClient
 import func Foundation.exp2
+import NIOCore
 
 /// Creates a ``RetryPolicy`` for ``TCClient`` to use.
 public struct RetryPolicyFactory {

--- a/Sources/TecoCore/Credential/CVMRoleCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/CVMRoleCredentialProvider.swift
@@ -32,7 +32,6 @@ import class Foundation.JSONDecoder
 import struct Foundation.Date
 import struct Foundation.TimeInterval
 import struct Foundation.URL
-
 import Logging
 import NIOCore
 import NIOHTTP1

--- a/Sources/TecoCore/Credential/CredentialProviderWithClient.swift
+++ b/Sources/TecoCore/Credential/CredentialProviderWithClient.swift
@@ -11,6 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOCore
+
 /// Credential provider that holds a ``TCClient``.
 protocol CredentialProviderWithClient: CredentialProvider {
     var client: TCClient { get }

--- a/Sources/TecoCore/Credential/OIDCRoleArnCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/OIDCRoleArnCredentialProvider.swift
@@ -12,9 +12,11 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
-import NIOCore
 import struct Foundation.Date
 import struct Foundation.TimeInterval
+import Logging
+import NIOCore
+import TecoSigner
 
 struct STSAssumeRoleWithWebIdentityRequest: TCRequestModel {
     /// Identity provider name.

--- a/Sources/TecoCore/Credential/STSCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/STSCredentialProvider.swift
@@ -15,6 +15,9 @@
 import AsyncHTTPClient
 import struct Foundation.Date
 import struct Foundation.TimeInterval
+import Logging
+import NIOCore
+import TecoSigner
 
 struct STSAssumeRoleRequest: TCRequestModel {
     /// Resource descriptions of a role, which can be obtained by clicking the role name in the CAM console.

--- a/Sources/TecoCore/Exports.swift
+++ b/Sources/TecoCore/Exports.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Teco open source project
 //
-// Copyright (c) 2022 the Teco project authors
+// Copyright (c) 2022-2023 the Teco project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !BUILDING_DOCC
 @_exported import protocol TecoSigner.Credential
 @_exported import struct TecoSigner.StaticCredential
 
@@ -22,3 +23,4 @@
 @_exported import class NIOCore.EventLoopFuture
 @_exported import protocol NIOCore.EventLoopGroup
 @_exported import struct NIOCore.TimeAmount
+#endif

--- a/Sources/TecoSigner/exports.swift
+++ b/Sources/TecoSigner/exports.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Teco open source project
 //
-// Copyright (c) 2022 the Teco project authors
+// Copyright (c) 2022-2023 the Teco project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,5 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !BUILDING_DOCC
 @_exported import struct NIOCore.ByteBuffer
-@_exported import struct NIOCore.TimeAmount
+#endif

--- a/Sources/TecoSigner/signer.swift
+++ b/Sources/TecoSigner/signer.swift
@@ -34,6 +34,7 @@ import class Foundation.DateFormatter
 import struct Foundation.Locale
 import struct Foundation.TimeZone
 import struct Foundation.URL
+import struct NIOCore.ByteBuffer
 import struct NIOHTTP1.HTTPHeaders
 import enum NIOHTTP1.HTTPMethod
 @_implementationOnly import struct Crypto.HMAC


### PR DESCRIPTION
This PR enables SPI documentation support for extensions and Linux platform. It also adds support for building without re-exported types, and sets up dedicated CI for the support.

The PR removes an unused exportation of `struct NIOCore.TimeAmount` from `TecoSigner`, which is breaking but shouldn't cause problems.