### PR TITLE
Removes `@preconcurrency` on `Atomics`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
           "branch": null,
-          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
-          "version": "1.0.2"
+          "revision": "6c89474e62719ddcc1e9614989fff2f68208fe10",
+          "version": "1.1.0"
         }
       },
       {

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),

--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -23,12 +23,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.6)
-@preconcurrency import Atomics
-#else
-import Atomics
-#endif
 import AsyncHTTPClient
+import Atomics
 import Dispatch
 import struct Foundation.URL
 import Logging


### PR DESCRIPTION
With Atomics 1.1 release, `ManagedAtomic` has gained native `Sendable` conformance, so we can remove the `@preconcurrency` mark.

To ensure all clients being updated, we updated the required `swift-atomics` version to 1.1.0 in `Package.swift` for Swift 5.6+, and Swift 5.5 users will use `Package@swift-5.5.swift` instead.