### PR TITLE
Rearranges documentation topics for `TecoPaginationHelpers`

### DIFF
--- a/Sources/TecoPaginationHelpers/Documentation.docc/index.md
+++ b/Sources/TecoPaginationHelpers/Documentation.docc/index.md
@@ -9,3 +9,23 @@ Some Tencent Cloud APIs provide query functionality and may return a list of obj
 This module provides experimental helpers on accessing the full paginated result either synchronously and asynchrously with `Teco`.
 
 > This module is work-in-progress and APIs are subject to change at the moment. Please use at your own risk, and do not use it in production.
+
+## Topics
+
+### Models
+
+- <doc:TCPaginatedRequest>
+- <doc:TCPaginatedResponse>
+- <doc:TecoCore/TCClient/PaginationError>
+
+### Pagination
+
+- <doc:TecoCore/TCClient/paginate(input:region:command:initialValue:reducer:logger:on:)>
+- <doc:TecoCore/TCClient/paginate(input:region:command:logger:on:)>
+- <doc:TecoCore/TCClient/paginate(input:region:command:callback:logger:on:)>
+
+### Paginator
+
+- <doc:TecoCore/TCClient/Paginator>
+- <doc:TecoCore/TCClient/PaginatorSequences>
+- <doc:TecoCore/TCClient/Paginator/makeAsyncSequences(input:region:command:logger:on:)>

--- a/Sources/TecoPaginationHelpers/TCClient+Paginator.swift
+++ b/Sources/TecoPaginationHelpers/TCClient+Paginator.swift
@@ -22,7 +22,7 @@ extension TCClient {
         responses: Paginator<Input, Input.Response>.ResponseSequence
     )
 
-    /// Helper types used to access paginated API results.
+    /// Helper namespace used to access paginated API results.
     public enum Paginator<Input: TCPaginatedRequest, Output: TCPaginatedResponse> where Input.Response == Output {
         /// Async sequence that returns paginated Tencent Cloud API responses.
         public struct ResponseSequence: AsyncSequence {
@@ -106,6 +106,7 @@ extension TCClient {
             }
         }
 
+        /// Async sequence that returns paginated Tencent Cloud API result items.
         public struct ResultSequence: AsyncSequence {
             public typealias Element = Output.Item
 


### PR DESCRIPTION
This PR customizes the "Topics" section of `TecoPaginationHelpers` documentation landing page. It also fixes some documentation in that target.