### PR TITLE
Cleans up CI workflow configurations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,14 +42,8 @@ jobs:
     steps:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v1
-        if: ${{ matrix.swift != '5.8' }}
         with:
           swift-version: ${{ matrix.swift }}
-      - name: Setup Swift
-        uses: slashmo/install-swift@v0.4.0
-        if: ${{ matrix.swift == '5.8' }}
-        with:
-          version: ${{ matrix.swift }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
@@ -57,7 +51,7 @@ jobs:
       - name: Test
         run: swift test
   build-with-docc:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,8 @@
 name: Build
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - '.github/workflows/build.yml'
-      - 'Package.*'
-      - 'Sources/**'
-      - 'Tests/**'
-      - '!**/*.docc/**'
   merge_group:
+    types:
+      - checks_requested
   pull_request:
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,11 +8,6 @@ on:
       - 'Package.swift'
       - 'Sources/**'
       - '!**/*.docc/**'
-  merge_group:
-    types:
-      - checks_requested
-    branches:
-      - 'main'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,11 @@ on:
   pull_request:
     branches:
       - 'main'
+    paths:
+      - '.github/workflows/integration.yml'
+      - 'Package.swift'
+      - 'Sources/**'
+      - '!**/*.docc/**'
 
 jobs:
   integration:


### PR DESCRIPTION
Since https://github.com/swift-actions/setup-swift supports Swift 5.8 now, let’s clean up the temporary workaround. This PR also reduces unnecessary test runs to save runner resource.