### PR TITLE
Removes usage of `NIOPreconcurrencySendable`

### DIFF
--- a/Sources/TecoCore/Credential/OIDCRoleArnCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/OIDCRoleArnCredentialProvider.swift
@@ -77,7 +77,7 @@ private struct STSAssumeRoleWithWebIdentityResponse: TCResponseModel {
 }
 
 /// Credential provider that returns temporary credentials acquired with OIDC.
-struct OIDCRoleArnCredentialProvider: CredentialProviderWithClient, NIOPreconcurrencySendable {
+struct OIDCRoleArnCredentialProvider: CredentialProviderWithClient, _TecoPreconcurrencySendable {
     let client: TCClient
 
     private let config: TCServiceConfig

--- a/Sources/TecoCore/Utils/Sendable.swift
+++ b/Sources/TecoCore/Utils/Sendable.swift
@@ -13,6 +13,8 @@
 
 #if compiler(>=5.6)
 public typealias _TecoSendable = Sendable
+@preconcurrency public protocol _TecoPreconcurrencySendable: Sendable {}
 #else
 public typealias _TecoSendable = Any
+public protocol _TecoPreconcurrencySendable {}
 #endif


### PR DESCRIPTION
`NIOPreconcurrencySendable` has been deprecated in https://github.com/apple/swift-nio/pull/2406. This PR replaced it with a custom protocol to avoid deprecation warnings.
