### PR TITLE
Improves DocC documentation and stabilizes `TecoPaginationHelpers`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,6 +1,10 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [TecoCore, TecoPaginationHelpers, TecoSigner]
+    - documentation_targets:
+        - TecoCore
+        - TecoDateHelpers
+        - TecoPaginationHelpers
+        - TecoSigner
       custom_documentation_parameters: ['--include-extended-types']
       platform: linux

--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -244,7 +244,7 @@ extension TCClient {
     ///    - input: API request payload.
     ///    - logger: Logger to log request details to.
     ///    - eventLoop: `EventLoop` to run request on.
-    /// - Returns: ``EventLoopFuture`` containing output object that completes when response is received.
+    /// - Returns: `EventLoopFuture` containing output object that completes when response is received.
     public func execute<Input: TCRequestModel, Output: TCResponseModel>(
         action: String,
         path: String = "/",
@@ -289,7 +289,7 @@ extension TCClient {
     ///    - skipAuthorization: If "Authorization" header should be set to `SKIP`.
     ///    - logger: Logger to log request details to.
     ///    - eventLoop: `EventLoop` to run request on.
-    /// - Returns: ``EventLoopFuture`` containing output object that completes when response is received.
+    /// - Returns: `EventLoopFuture` containing output object that completes when response is received.
     public func execute<Output: TCResponseModel>(
         action: String,
         path: String = "/",

--- a/Sources/TecoCore/Common/TCService.swift
+++ b/Sources/TecoCore/Common/TCService.swift
@@ -54,7 +54,7 @@ public protocol TCService: _TecoSendable {
 extension TCService {
     /// Default region of the service to operate on.
     public var defaultRegion: TCRegion? { config.region }
-    /// ``EventLoopGroup`` the service is using.
+    /// `EventLoopGroup` the service is using.
     public var eventLoopGroup: EventLoopGroup { client.eventLoopGroup }
  
     /// Service endpoint URL for provided region.

--- a/Sources/TecoCore/Credential/CredentialProviderFactory.swift
+++ b/Sources/TecoCore/Credential/CredentialProviderFactory.swift
@@ -71,7 +71,7 @@ extension CredentialProviderFactory {
         Self(cb: factory)
     }
 
-    /// Get ``Credential`` details from the environment.
+    /// Get `Credential` details from the environment.
     ///
     /// Looks in environment variables `TENCENTCLOUD_SECRET_ID`, `TENCENTCLOUD_SECRET_KEY` and `TENCENTCLOUD_TOKEN`.
     public static var environment: CredentialProviderFactory {
@@ -95,7 +95,7 @@ extension CredentialProviderFactory {
         }
     }
 
-    /// Get ``Credential`` details from SCF environment variables.
+    /// Get `Credential` details from SCF environment variables.
     ///
     /// Looks in environment variables `TENCENTCLOUD_SECRETID`, `TENCENTCLOUD_SECRETKEY` and `TENCENTCLOUD_SESSIONTOKEN`.
     public static var scf: CredentialProviderFactory {

--- a/Sources/TecoCore/Documentation.docc/index.md
+++ b/Sources/TecoCore/Documentation.docc/index.md
@@ -11,3 +11,66 @@ The core library of Teco, an open-source Tencent Cloud SDK for Swift.
 The Teco project, heavily inspired by [Soto](https://github.com/soto-project), aims to provide a fully-functional and powerful Tencent Cloud SDK that allows Swift developers to use Tencent Cloud APIs easily within their server or client applications.
 
 This library provides most common functionalities around calling Tencent Cloud APIs.
+
+## Topics
+
+### Client
+
+- ``TCClient``
+- ``TCPayload``
+
+### Services
+
+- ``TCService``
+- ``TCServiceConfig``
+
+- ``TCRegion``
+
+### Models
+
+- ``TCModel``
+
+- ``TCInputModel``
+- ``TCOutputModel``
+
+- ``TCRequestModel``
+- ``TCResponseModel``
+
+### Credentials
+
+- ``CredentialProvider``
+- ``CredentialProviderFactory``
+- ``CredentialProviderError``
+
+- ``ExpiringCredential``
+
+- ``TemporaryCredential``
+- ``TecoSigner/StaticCredential``
+
+- ``DeferredCredentialProvider``
+- ``TemporaryCredentialProvider``
+- ``NullCredentialProvider``
+
+### Retry
+
+- ``RetryPolicy``
+- ``RetryPolicyFactory``
+
+- ``RetryStatus``
+
+### Endpoint
+
+- ``EndpointProvider``
+- ``EndpointProviderFactory``
+
+### Error handling
+
+- ``TCErrorContext``
+
+- ``TCErrorType``
+- ``TCServiceErrorType``
+
+- ``TCRawError``
+- ``TCRawServiceError``
+
+- ``TCCommonError``

--- a/Sources/TecoCore/Documentation.docc/index.md
+++ b/Sources/TecoCore/Documentation.docc/index.md
@@ -1,5 +1,9 @@
 #  ``TecoCore``
 
+@Metadata {
+    @DisplayName("Teco Core")
+}
+
 The core library of Teco, an open-source Tencent Cloud SDK for Swift.
 
 ## Overview

--- a/Sources/TecoCore/Transport/HTTPClient.swift
+++ b/Sources/TecoCore/Transport/HTTPClient.swift
@@ -35,6 +35,7 @@ extension AsyncHTTPClient.HTTPClient {
     ///   - request: HTTP request.
     ///   - timeout: If execution is idle for longer than timeout then throw error.
     ///   - eventLoop: `EventLoop` to run request on.
+    ///   - logger: The logger to use for this request.
     /// - Returns: `EventLoopFuture` that will be fulfilled with request response.
     internal func execute(
         request: TCHTTPRequest,

--- a/Sources/TecoCore/Transport/HTTPClient.swift
+++ b/Sources/TecoCore/Transport/HTTPClient.swift
@@ -44,7 +44,7 @@ extension AsyncHTTPClient.HTTPClient {
         logger: Logger
     ) -> EventLoopFuture<TCHTTPResponse> {
         do {
-            let request = try HTTPClient.Request(
+            let request = try Request(
                 url: request.url,
                 method: request.method,
                 headers: request.headers,
@@ -56,7 +56,7 @@ extension AsyncHTTPClient.HTTPClient {
                 on: eventLoop,
                 logger: logger
             ).flatMapThrowing { response in
-                try TCHTTPResponse(status: response.status, headers: response.headers, body: response.body)
+                try .init(status: response.status, headers: response.headers, body: response.body)
             }
         } catch {
             return eventLoopGroup.next().makeFailedFuture(error)
@@ -75,7 +75,7 @@ extension AsyncHTTPClient.HTTPClient {
         timeout: TimeAmount,
         on eventLoop: EventLoop,
         logger: Logger? = nil
-    ) -> EventLoopFuture<HTTPClient.Response> {
+    ) -> EventLoopFuture<Response> {
         self.execute(
             request: request,
             eventLoop: .delegate(on: eventLoop),

--- a/Sources/TecoDateHelpers/Documentation.docc/index.md
+++ b/Sources/TecoDateHelpers/Documentation.docc/index.md
@@ -1,0 +1,35 @@
+# ``TecoDateHelpers``
+
+@Metadata {
+    @DisplayName("Teco Date Helpers")
+}
+
+Date encoding support for Tencent Cloud API models.
+
+## Overview
+
+This library provides property wrappers for properly encoding and decoding `Date` values in `TCModel`.
+
+## Topics
+
+### Property wrappers
+
+- ``TCDateWrapper``
+
+- ``TCDateEncoding``
+- ``TCTimestampEncoding``
+- ``TCTimestampISO8601Encoding``
+
+### Date values
+
+- ``TCDateValue``
+
+- ``Foundation/Date``
+- ``Swift/Optional``
+
+### Date encoding
+
+- ``TCDateFormatter``
+
+- ``Swift/KeyedEncodingContainer``
+- ``Swift/KeyedDecodingContainer``

--- a/Sources/TecoPaginationHelpers/Documentation.docc/index.md
+++ b/Sources/TecoPaginationHelpers/Documentation.docc/index.md
@@ -1,14 +1,12 @@
 # ``TecoPaginationHelpers``
 
-Pagination support for Tencent Cloud APIs. (Experimental)
+Pagination support for Tencent Cloud APIs.
 
 ## Overview
 
 Some Tencent Cloud APIs provide query functionality and may return a list of objects with arbitrary length. Most of them come with support for paginating the list, i.e., they will return the list in fixed-size chunks, sometimes also with a token to be used in the next request.
 
-This module provides experimental helpers on accessing the full paginated result either synchronously and asynchrously with `Teco`.
-
-> This module is work-in-progress and APIs are subject to change at the moment. Please use at your own risk, and do not use it in production.
+This module provides helpers for accessing the full paginated result either synchronously and asynchrously with `Teco`.
 
 ## Topics
 

--- a/Sources/TecoPaginationHelpers/Documentation.docc/index.md
+++ b/Sources/TecoPaginationHelpers/Documentation.docc/index.md
@@ -1,5 +1,9 @@
 # ``TecoPaginationHelpers``
 
+@Metadata {
+    @DisplayName("Teco Pagination Helpers")
+}
+
 Pagination support for Tencent Cloud APIs.
 
 ## Overview

--- a/Sources/TecoPaginationHelpers/Documentation.docc/index.md
+++ b/Sources/TecoPaginationHelpers/Documentation.docc/index.md
@@ -12,18 +12,19 @@ This module provides helpers for accessing the full paginated result either sync
 
 ### Models
 
-- <doc:TCPaginatedRequest>
-- <doc:TCPaginatedResponse>
-- <doc:TecoCore/TCClient/PaginationError>
+- ``TCPaginatedRequest``
+- ``TCPaginatedResponse``
+
+- ``TecoCore/TCClient/PaginationError``
 
 ### Pagination
 
-- <doc:TecoCore/TCClient/paginate(input:region:command:initialValue:reducer:logger:on:)>
-- <doc:TecoCore/TCClient/paginate(input:region:command:logger:on:)>
-- <doc:TecoCore/TCClient/paginate(input:region:command:callback:logger:on:)>
+- ``TecoCore/TCClient/paginate(input:region:command:initialValue:reducer:logger:on:)``
+- ``TecoCore/TCClient/paginate(input:region:command:logger:on:)``
+- ``TecoCore/TCClient/paginate(input:region:command:callback:logger:on:)``
 
 ### Paginator
 
-- <doc:TecoCore/TCClient/Paginator>
-- <doc:TecoCore/TCClient/PaginatorSequences>
-- <doc:TecoCore/TCClient/Paginator/makeAsyncSequences(input:region:command:logger:on:)>
+- ``TecoCore/TCClient/Paginator``
+- ``TecoCore/TCClient/PaginatorSequences``
+- ``TecoCore/TCClient/Paginator/makeAsyncSequences(input:region:command:logger:on:)``

--- a/Sources/TecoPaginationHelpers/TCClient+Pagination.swift
+++ b/Sources/TecoPaginationHelpers/TCClient+Pagination.swift
@@ -26,7 +26,7 @@ extension TCClient {
     ///   - reducer: Function to combine responses into result value. This combined result is returned along with a boolean indicating if the pagination should continue.
     ///   - logger: Logger to log request details to.
     ///   - eventLoop: `EventLoop` to run request on.
-    /// - Returns: ``EventLoopFuture`` containing the combined result.
+    /// - Returns: `EventLoopFuture` containing the combined result.
     public func paginate<Result, Input: TCPaginatedRequest, Output: TCPaginatedResponse>(
         input: Input,
         region: TCRegion? = nil,
@@ -72,7 +72,7 @@ extension TCClient {
     ///   - command: Command to be paginated.
     ///   - logger: Logger to log request details to.
     ///   - eventLoop: `EventLoop` to run request on.
-    /// - Returns: ``EventLoopFuture`` containing total item count and complete output object list from a series of requests.
+    /// - Returns: `EventLoopFuture` containing total item count and complete output object list from a series of requests.
     public func paginate<Input: TCPaginatedRequest, Output: TCPaginatedResponse>(
         input: Input,
         region: TCRegion? = nil,

--- a/Sources/TecoPaginationHelpers/TCClient+Pagination.swift
+++ b/Sources/TecoPaginationHelpers/TCClient+Pagination.swift
@@ -125,8 +125,8 @@ extension TCClient {
     }
 }
 
-extension Logger {
-    fileprivate func attachingPaginationContext(id: Int) -> Logger {
+private extension Logger {
+    func attachingPaginationContext(id: Int) -> Logger {
         var logger = self
         logger[metadataKey: "tc-client-pagination-seq"] = "\(id)"
         return logger

--- a/Sources/TecoPaginationHelpers/TCClient+PaginationError.swift
+++ b/Sources/TecoPaginationHelpers/TCClient+PaginationError.swift
@@ -14,7 +14,7 @@
 import TecoCore
 
 extension TCClient {
-    /// Errors returned by ``TCClient`` pagination helpers.
+    /// Errors returned by `TCClient` pagination helpers.
     public enum PaginationError: Error, Equatable {
         /// Total item count changed during pagination.
         case totalCountChanged

--- a/Sources/TecoSigner/Documentation.docc/index.md
+++ b/Sources/TecoSigner/Documentation.docc/index.md
@@ -1,5 +1,9 @@
 #  ``TecoSigner``
 
+@Metadata {
+    @DisplayName("Teco Signer")
+}
+
 Signing helpers for Tencent Cloud API signature V3.
 
 ## Overview

--- a/Sources/TecoSigner/Documentation.docc/index.md
+++ b/Sources/TecoSigner/Documentation.docc/index.md
@@ -13,10 +13,11 @@ It also defines the interface of Tencent Cloud security credentials.
 ### Signing
 
 - <doc:SignRequests>
-- <doc:TCSigner>
-- <doc:TCSignerError>
+
+- ``TCSigner``
+- ``TCSignerError``
 
 ### Credentials
 
-- <doc:Credential>
-- <doc:StaticCredential>
+- ``Credential``
+- ``StaticCredential``


### PR DESCRIPTION
This PR introduces DocC bundle for `TecoDateHelpers`, and adds topics arrangement for `TecoCore`. It also marks `TecoPaginationHelpers` as stable.

Other improvements include removing broken symbol links and updating module display names.