### PR TITLE
Updates `TCRequestModel` and `TCResponseModel` to shorter names

### DIFF
--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -36,9 +36,9 @@ import TecoSigner
 
 /// Client managing communication with Tencent Cloud services.
 ///
-/// This is the workhorse of TecoCore. You provide it with a ``TCRequestModel``, it converts it to `TCHTTPRequest` which is then converted to a raw `HTTPClient` request. This is then sent to Tencent Cloud.
+/// This is the workhorse of TecoCore. You provide it with a ``TCRequest``, it converts it to `TCHTTPRequest` which is then converted to a raw `HTTPClient` request. This is then sent to Tencent Cloud.
 ///
-/// When the response from Tencent Cloud is received, it will be converted to a `TCHTTPResponse`, which is then decoded to generate a ``TCResponseModel`` or to create and throw a ``TCErrorType``.
+/// When the response from Tencent Cloud is received, it will be converted to a `TCHTTPResponse`, which is then decoded to generate a ``TCResponse`` or to create and throw a ``TCErrorType``.
 public final class TCClient: _TecoSendable {
     // MARK: Member variables
 
@@ -245,7 +245,7 @@ extension TCClient {
     ///    - logger: Logger to log request details to.
     ///    - eventLoop: `EventLoop` to run request on.
     /// - Returns: `EventLoopFuture` containing output object that completes when response is received.
-    public func execute<Input: TCRequestModel, Output: TCResponseModel>(
+    public func execute<Input: TCRequest, Output: TCResponse>(
         action: String,
         path: String = "/",
         region: TCRegion? = nil,
@@ -290,7 +290,7 @@ extension TCClient {
     ///    - logger: Logger to log request details to.
     ///    - eventLoop: `EventLoop` to run request on.
     /// - Returns: `EventLoopFuture` containing output object that completes when response is received.
-    public func execute<Output: TCResponseModel>(
+    public func execute<Output: TCResponse>(
         action: String,
         path: String = "/",
         region: TCRegion? = nil,
@@ -382,7 +382,7 @@ extension TCClient {
 
 extension TCClient {
     /// The core executor.
-    private func execute<Output: TCResponseModel>(
+    private func execute<Output: TCResponse>(
         action: String,
         createRequest: @autoclosure @escaping () throws -> TCHTTPRequest,
         skipAuthorization: Bool,
@@ -417,7 +417,7 @@ extension TCClient {
     }
 
     /// The core invoker.
-    private func invoke<Output: TCResponseModel>(
+    private func invoke<Output: TCResponse>(
         with serviceConfig: TCServiceConfig,
         eventLoop: EventLoop,
         logger: Logger,

--- a/Sources/TecoCore/Common/TCModel.swift
+++ b/Sources/TecoCore/Common/TCModel.swift
@@ -12,8 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 /// Protocol for the input and output data objects for all Tencent Cloud service commands.
-///
-/// The model must be codable in both directions.
 public protocol TCModel: Codable, _TecoSendable {}
 
 /// ``TCModel`` that can be used in API input.

--- a/Sources/TecoCore/Common/TCModel.swift
+++ b/Sources/TecoCore/Common/TCModel.swift
@@ -25,12 +25,12 @@ public protocol TCInputModel: TCModel {}
 public protocol TCOutputModel: TCModel {}
 
 /// ``TCInputModel`` that serves as request payload.
-public protocol TCRequestModel: TCInputModel {}
+public protocol TCRequest: TCInputModel {}
 
 /// ``TCOutputModel`` that serves as response payload.
 ///
 /// Holds the request ID assigned by Tencent Cloud.
-public protocol TCResponseModel: TCOutputModel {
+public protocol TCResponse: TCOutputModel {
     /// Request ID assigned by Tencent Cloud uniquely for every API request.
     var requestId: String { get }
 }

--- a/Sources/TecoCore/Credential/OIDCRoleArnCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/OIDCRoleArnCredentialProvider.swift
@@ -18,7 +18,7 @@ import Logging
 import NIOCore
 import TecoSigner
 
-struct STSAssumeRoleWithWebIdentityRequest: TCRequestModel {
+struct STSAssumeRoleWithWebIdentityRequest: TCRequest {
     /// Identity provider name.
     let providerId: String
     /// OIDC token issued by the IdP.
@@ -49,7 +49,7 @@ struct STSAssumeRoleWithWebIdentityRequest: TCRequestModel {
     }
 }
 
-private struct STSAssumeRoleWithWebIdentityResponse: TCResponseModel {
+private struct STSAssumeRoleWithWebIdentityResponse: TCResponse {
     /// Temporary security credentials.
     let credentials: Credentials
     /// Credentials expiration time in Unix timestamp.

--- a/Sources/TecoCore/Credential/STSCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/STSCredentialProvider.swift
@@ -19,7 +19,7 @@ import Logging
 import NIOCore
 import TecoSigner
 
-struct STSAssumeRoleRequest: TCRequestModel {
+struct STSAssumeRoleRequest: TCRequest {
     /// Resource descriptions of a role, which can be obtained by clicking the role name in the CAM console.
     ///
     /// General role example:
@@ -64,7 +64,7 @@ struct STSAssumeRoleRequest: TCRequestModel {
     }
 }
 
-private struct STSAssumeRoleResponse: TCResponseModel {
+private struct STSAssumeRoleResponse: TCResponse {
     /// Temporary security credentials.
     let credentials: Credentials
     /// Credentials expiration time in Unix timestamp.

--- a/Sources/TecoCore/Documentation.docc/TCModel.md
+++ b/Sources/TecoCore/Documentation.docc/TCModel.md
@@ -1,0 +1,5 @@
+# ``TCModel``
+
+## Discussions
+
+A model must be codable in both directions.

--- a/Sources/TecoCore/Documentation.docc/index.md
+++ b/Sources/TecoCore/Documentation.docc/index.md
@@ -34,7 +34,10 @@ This library provides most common functionalities around calling Tencent Cloud A
 - ``TCOutputModel``
 
 - ``TCRequest``
+- ``TCRequestModel``
+
 - ``TCResponse``
+- ``TCResponseModel``
 
 ### Credentials
 

--- a/Sources/TecoCore/Documentation.docc/index.md
+++ b/Sources/TecoCore/Documentation.docc/index.md
@@ -33,8 +33,8 @@ This library provides most common functionalities around calling Tencent Cloud A
 - ``TCInputModel``
 - ``TCOutputModel``
 
-- ``TCRequestModel``
-- ``TCResponseModel``
+- ``TCRequest``
+- ``TCResponse``
 
 ### Credentials
 

--- a/Sources/TecoCore/Transport/TCHTTPResponse.swift
+++ b/Sources/TecoCore/Transport/TCHTTPResponse.swift
@@ -70,7 +70,7 @@ struct TCHTTPResponse {
     }
 
     /// Generate ``TCModel`` from ``TCHTTPResponse``.
-    internal func generateOutputData<Output: TCResponseModel>(
+    internal func generateOutputData<Output: TCResponse>(
         errorType: TCErrorType.Type? = nil,
         errorLogLevel: Logger.Level = .info,
         logger: Logger
@@ -114,7 +114,7 @@ struct TCHTTPResponse {
 
 extension TCHTTPResponse {
     /// Container that holds an API response.
-    private struct Container<Output: TCResponseModel>: Decodable {
+    private struct Container<Output: TCResponse>: Decodable {
         let response: Output
 
         enum CodingKeys: String, CodingKey {
@@ -131,7 +131,7 @@ extension TCHTTPResponse {
     }
 
     /// Error payload used in JSON output.
-    private struct APIError: TCResponseModel, Error {
+    private struct APIError: TCResponse, Error {
         let error: Error
         let requestId: String
 

--- a/Sources/TecoCore/deprecated.swift
+++ b/Sources/TecoCore/deprecated.swift
@@ -17,6 +17,16 @@ import NIOCore
 import NIOFoundationCompat
 import NIOHTTP1
 
+/// ``TCInputModel`` that serves as request payload.
+@available(*, deprecated, renamed: "TCRequest")
+public typealias TCRequestModel = TCRequest
+
+/// ``TCOutputModel`` that serves as response payload.
+///
+/// Holds the request ID assigned by Tencent Cloud.
+@available(*, deprecated, renamed: "TCResponse")
+public typealias TCResponseModel = TCResponse
+
 /// Holds a request or response payload.
 ///
 /// Currently request or response payloads only come in the form of a `ByteBuffer`.

--- a/Sources/TecoPaginationHelpers/TCPaginatedModel.swift
+++ b/Sources/TecoPaginationHelpers/TCPaginatedModel.swift
@@ -20,7 +20,7 @@ public typealias _PaginationSendable = Any
 #endif
 
 /// Tencent Cloud API request model that represents a paginated query.
-public protocol TCPaginatedRequest: TCRequestModel {
+public protocol TCPaginatedRequest: TCRequest {
     /// Paginated response type associated with the request.
     associatedtype Response: TCPaginatedResponse
 
@@ -29,7 +29,7 @@ public protocol TCPaginatedRequest: TCRequestModel {
 }
 
 /// Tencent Cloud API response model that contains a list of paginated result and a total count.
-public protocol TCPaginatedResponse: TCResponseModel {
+public protocol TCPaginatedResponse: TCResponse {
     /// The total count type to be extracted from the response.
     associatedtype Count: _PaginationSendable, Equatable
     /// The queried item type.


### PR DESCRIPTION
This PR simplifies the name of `TCRequestModel` to `TCRequest`, and `TCResponseModel` to `TCResponse`. This is made possible by #33, which eliminates internal types with these names. This change aligns the naming with `TCPaginatedRequest` and `TCPaginatedResponse` from `TecoPaginationHelpers`.