### PR TITLE
Implements signer for `HmacSHA1` (v1 signature)

### DIFF
--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -60,7 +60,7 @@ public final class TCClient: _TecoSendable {
     /// Logger used for non-request based output.
     private let clientLogger: Logger
     /// Default signing mode.
-    private let signingMode: TCSigner.SigningMode
+    private let signingMode: TCSignerV3.SigningMode
     /// Custom client options.
     private let options: Options
     /// Holds the client shutdown state.
@@ -371,9 +371,9 @@ extension TCClient {
             }
     }
 
-    private func createSigner(serviceConfig: TCServiceConfig, logger: Logger) -> EventLoopFuture<TCSigner> {
+    private func createSigner(serviceConfig: TCServiceConfig, logger: Logger) -> EventLoopFuture<TCSignerV3> {
         return credentialProvider.getCredential(on: eventLoopGroup.next(), logger: logger).map { credential in
-            TCSigner(credential: credential, service: serviceConfig.service)
+            TCSignerV3(credential: credential, service: serviceConfig.service)
         }
     }
 }

--- a/Sources/TecoCore/Transport/TCHTTPRequest.swift
+++ b/Sources/TecoCore/Transport/TCHTTPRequest.swift
@@ -51,7 +51,7 @@ struct TCHTTPRequest {
     /// - Parameters:
     ///   - signer: Tencent Cloud API signer to use.
     ///   - mode: Signing mode.
-    internal mutating func signHeaders(with signer: TCSigner, mode: TCSigner.SigningMode) {
+    internal mutating func signHeaders(with signer: TCSignerV3, mode: TCSignerV3.SigningMode) {
         // if credentials are empty don't sign request
         guard mode == .skip || !signer.credential.isEmpty else {
             assertionFailure("Empty credential provided for request!")

--- a/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV1.md
+++ b/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV1.md
@@ -127,20 +127,31 @@ let signedQuery = try signer.signQueryString(url: url, query: query)
 If a `query` parameter is provided along with `url`, the signer assumes the request to use `POST` method by default. It'll also use current time and add a random `nonce` for the request. You can override the behavior based on your use case. The following sample signs a request for 10 seconds ago, with `nonce` set to `888`.
 
 ```swift
-let signedQueryWithNonce = signer.signQueryString(
-    host: "region.tencentcloudapi.com",
+let signedQueryWithNonce = try signer.signQueryString(
+    url: "https://region.tencentcloudapi.com/",
     queryItems: [
         .init(name: "Action", value: "DescribeRegions"),
         .init(name: "Product", value: "cvm"),
         .init(name: "Version", value: "2022-06-27"),
     ],
-    method: .POST,
     nonce: 888,
     date: Date(timeIntervalSinceNow: -10)
 )
 ```
 
 Note that the non-throwing variants ``TCSignerV1/signQueryString(host:path:queryItems:method:omitSessionToken:nonce:date:)`` and ``TCSignerV1/signQueryString(host:path:query:method:omitSessionToken:nonce:date:)`` are still available, but you'll have to specify the `method` parameter for a `POST` request.
+
+```swift
+let signedHandcraftQuery = signer.signQueryString(
+    host: "tag.tencentcloudapi.com",
+    queryItems: [
+        .init(name: "Action", value: "GetTagValues"),
+        .init(name: "Version", value: "2018-08-13"),
+        .init(name: "TagKeys.0", value: "平台"),
+    ],
+    method: .POST
+)
+```
 
 There are some other configurations to control signing behavior. For example, `omitSessionToken` specifies whether ``Credential/token`` is used for signature.
 

--- a/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV1.md
+++ b/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV1.md
@@ -1,0 +1,151 @@
+# Signing API requests with `HmacSHA1` (Unrecommended)
+
+Generate properly-signed URL query for your Tencent Cloud API request.
+
+## Overview
+
+Tencent Cloud API authenticates every single request, i.e., the request must be signed using the security credentials in the designated steps. Each request has to contain the signature information and be sent in the specified way and format.
+
+``TCSignerV1`` makes it easy to sign an API request using the `HmacSHA1` signature algorithm. It may be required for some legacy APIs, but for higher security you should use ``TCSignerV3`` as described in <doc:SignRequestsV3> in the first place.
+
+## Create a signer instance
+
+To sign an API request, you need a valid security credential. Basically, this can be the static API access key obtained from the [CAM console](https://console.tencentcloud.com/cam/capi), in the form of paired secret ID and secret key.
+
+```swift
+let credential = StaticCredential(secretId: "YOUR_SECRET_ID", secretKey: "YOUR_SECRET_KEY")
+```
+
+> It's strongly unrecommended to supply the API key of a root account directly due to high security risk.
+>
+> To learn more about using sub-accounts, see [Creating and Authorizing Sub-account](https://www.tencentcloud.com/document/product/598/40985) and [Access Key](https://www.tencentcloud.com/document/product/598/32675).
+>
+> For other security advice, see [Security Best Practice](https://www.tencentcloud.com/document/product/598/10592).
+
+Then create a signer to sign requests.
+
+```swift
+let signer = TCSignerV1(credential: credential)
+```
+
+## Sign a `GET` request
+
+### Prepare the request URL
+
+Before performing the signing step, you need to have a request URL.
+
+The URL should be compatible with [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986), which requires specific characters to be percent-encoded. The following sample shows a simple `GET` request URL.
+
+```swift
+let url = URL(string: "https://region.tencentcloudapi.com/?Action=DescribeProducts&Version=2022-06-27")!
+```
+
+> URL supplied for signature should not be changed once the request is signed.
+
+### Generate signed query string
+
+You can generate signed query string using ``TCSignerV1/signQueryString(url:method:omitSessionToken:nonce:date:)-91hjz``. The following sample shows a simple signing step using request URL.
+
+```swift
+let signedQuery = try signer.signQueryString(url: url)
+```
+
+> The signer will throw ``TCSignerError/invalidURL`` if the URL is malformed.
+
+By default, the signer assumes the request to use current time and `GET` method, and adds a random `nonce` for the request. You can override the behavior based on your use case. The following sample signs a request for 10 seconds ago, with `nonce` set to `888`.
+
+```swift
+let signedQueryWithNonce = signer.signQueryString(
+    host: "region.tencentcloudapi.com",
+    queryItems: [
+        .init(name: "Action", value: "DescribeRegions"),
+        .init(name: "Product", value: "cvm"),
+        .init(name: "Version", value: "2022-06-27"),
+    ],
+    nonce: 888,
+    date: Date(timeIntervalSinceNow: -10)
+)
+```
+
+Note that there are non-throwing variants ``TCSignerV1/signQueryString(host:path:queryItems:method:omitSessionToken:nonce:date:)`` and ``TCSignerV1/signQueryString(host:path:query:method:omitSessionToken:nonce:date:)`` which accepts the request host, path and query directly.
+
+There are some other configurations to control signing behavior. For example, `omitSessionToken` specifies whether ``Credential/token`` is used for signature.
+
+```swift
+let signedQueryOmittingToken = try signer.signQueryString(url: url, omitSessionToken: true)
+```
+
+### Use the signed query
+
+With a signed query string, you can now form the signed request URL. You can construct a new URL string using the same host and path that's used for signing.
+
+```swift
+guard let url = URL(string: "https://region.tencentcloudapi.com/?\(signedQuery)") else {
+    fatalError("Invalid request!")
+}
+```
+
+Instead of using a URL string, you can also start with a `URL` and update it safely using `URLComponents`.
+
+```swift
+guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
+      case urlComponents.percentEncodedQuery = signedQuery,
+      let signedURL = urlComponents.url
+else {
+    fatalError("Invalid request!")
+}
+```
+
+## Sign a `POST` request
+
+### Prepare the request URL and body
+
+Before performing the signing step, you need to have a request URL. `POST` request URL usually comes with no query, as shown in the following example.
+
+```swift
+let url = URL(string: "https://region.tencentcloudapi.com")!
+```
+
+> URL supplied for signature should not be changed once the request is signed.
+
+``TCSignerV1`` (and the `HmacSHA1` algorithm) only supports signing a `POST` request with `application/x-www-form-urlencoded` content type, which basically sends the URL query as `POST` body. The following sample shows a simple `POST` request body.
+
+```swift
+let query = "Action=DescribeProducts&Version=2022-06-27"
+```
+
+### Generate signed query string
+
+You can generate signed query string using ``TCSignerV1/signQueryString(url:query:method:omitSessionToken:nonce:date:)-8klqy``. The following sample shows a simple signing step using request URL and body.
+
+```swift
+let signedQuery = try signer.signQueryString(url: url, query: query)
+```
+
+> The signer will throw ``TCSignerError/invalidURL`` if the URL is malformed.
+
+If a `query` parameter is provided along with `url`, the signer assumes the request to use `POST` method by default. It'll also use current time and add a random `nonce` for the request. You can override the behavior based on your use case. The following sample signs a request for 10 seconds ago, with `nonce` set to `888`.
+
+```swift
+let signedQueryWithNonce = signer.signQueryString(
+    host: "region.tencentcloudapi.com",
+    queryItems: [
+        .init(name: "Action", value: "DescribeRegions"),
+        .init(name: "Product", value: "cvm"),
+        .init(name: "Version", value: "2022-06-27"),
+    ],
+    method: .POST,
+    nonce: 888,
+    date: Date(timeIntervalSinceNow: -10)
+)
+```
+
+Note that the non-throwing variants ``TCSignerV1/signQueryString(host:path:queryItems:method:omitSessionToken:nonce:date:)`` and ``TCSignerV1/signQueryString(host:path:query:method:omitSessionToken:nonce:date:)`` are still available, but you'll have to specify the `method` parameter for a `POST` request.
+
+There are some other configurations to control signing behavior. For example, `omitSessionToken` specifies whether ``Credential/token`` is used for signature.
+
+```swift
+let signedQueryOmittingToken = try signer.signQueryString(url: url, query omitSessionToken: true)
+```
+
+You can now use the signed query string as the `POST` request body, and send it to the request URL.

--- a/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV3.md
+++ b/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV3.md
@@ -1,4 +1,4 @@
-# Signing API requests
+# Signing API requests with `TC3-HMAC-SHA256`
 
 Generate properly-signed HTTP headers for your Tencent Cloud API request.
 
@@ -6,7 +6,7 @@ Generate properly-signed HTTP headers for your Tencent Cloud API request.
 
 Tencent Cloud API authenticates every single request, i.e., the request must be signed using the security credentials in the designated steps. Each request has to contain the signature information and be sent in the specified way and format.
 
-``TCSigner`` makes it easy to sign an API request using the `TC3-HMAC-SHA256` signature algorithm, which is recommended for higher security and better performance.
+``TCSignerV3`` makes it easy to sign an API request using the `TC3-HMAC-SHA256` signature algorithm, which is recommended for higher security and better performance.
 
 ## Create a signer instance
 
@@ -25,7 +25,7 @@ let credential = StaticCredential(secretId: "YOUR_SECRET_ID", secretKey: "YOUR_S
 Then create a signer to sign requests for a service.
 
 ```swift
-let signer = TCSigner(credential: credential, service: "cvm")
+let signer = TCSignerV3(credential: credential, service: "cvm")
 ```
 
 ## Prepare a request for signing
@@ -38,10 +38,10 @@ Make sure the request URL is compatible with [RFC 3986](https://www.rfc-editor.o
 let url = URL(string: "https://cvm.tencentcloudapi.com/")!
 ```
 
-Wrap the request body into ``TCSigner/BodyData``. The following sample uses an empty JSON body.
+Wrap the request body into ``TCSignerV3/BodyData``. The following sample uses an empty JSON body.
 
 ```swift
-let body: TCSigner.BodyData = .string("{}")
+let body: TCSignerV3.BodyData = .string("{}")
 ```
 
 Supply required HTTP headers, which must include `Content-Type`. Common parameters often use keys in the form of `X-TC-<Param>`. You may also add custom header fields depending on your use case. 
@@ -59,7 +59,7 @@ let headers: HTTPHeaders = [
 
 ## Generate signed request headers
 
-You can generate signed headers using ``TCSigner/signHeaders(url:method:headers:body:mode:omitSessionToken:date:)-7a50k``. The following sample shows a simple signing step with request URL, headers and body.
+You can generate signed headers using ``TCSignerV3/signHeaders(url:method:headers:body:mode:omitSessionToken:date:)-b8bp``. The following sample shows a simple signing step with request URL, headers and body.
 
 ```swift
 let signedHeaders = signer.signHeaders(url: url, headers: headers, body: body)
@@ -81,7 +81,7 @@ let signedHeadersForGETRequest = try signer.signHeaders(
 )
 ```
 
-Note that there is a convenience helper ``TCSigner/signHeaders(url:method:headers:body:mode:omitSessionToken:date:)-9aula`` which accepts the request URL in string, and may throw if the input is not valid URL.
+Note that there is a convenience helper ``TCSignerV3/signHeaders(url:method:headers:body:mode:omitSessionToken:date:)-1rcp6`` which accepts the request URL in string, and may throw if the input is not valid URL.
 
 There are some other configurations to control signing behavior. For example, `omitSessionToken` specifies whether ``Credential/token`` is used for signature.
 
@@ -94,7 +94,7 @@ let signedHeadersOmittingToken = signer.signHeaders(
 )
 ```
 
-``TCSigner/SigningMode`` controls how the signer signs a request. By default, the signer takes all statically available headers for maximal security. The following sample uses minimal signing mode, which is slightly faster while being less secure.
+``TCSignerV3/SigningMode`` controls how the signer signs a request. By default, the signer takes all statically available headers for maximal security. The following sample uses minimal signing mode, which is slightly faster while being less secure.
 
 ```swift
 let signedHeadersUsingMinimalMode = signer.signHeaders(

--- a/Sources/TecoSigner/Documentation.docc/SigningMode/minimal.md
+++ b/Sources/TecoSigner/Documentation.docc/SigningMode/minimal.md
@@ -1,4 +1,4 @@
-# ``TecoSigner/TCSigner/SigningMode/minimal``
+# ``TecoSigner/TCSignerV3/SigningMode/minimal``
 
 ## Discussion
 

--- a/Sources/TecoSigner/Documentation.docc/SigningMode/skip.md
+++ b/Sources/TecoSigner/Documentation.docc/SigningMode/skip.md
@@ -1,4 +1,4 @@
-# ``TecoSigner/TCSigner/SigningMode/skip``
+# ``TecoSigner/TCSignerV3/SigningMode/skip``
 
 ## Discussion
 

--- a/Sources/TecoSigner/Documentation.docc/index.md
+++ b/Sources/TecoSigner/Documentation.docc/index.md
@@ -16,9 +16,10 @@ It also defines the interface of Tencent Cloud security credentials.
 
 ### Signing
 
-- <doc:SignRequests>
-
+- <doc:SignRequestsV3>
+- ``TCSignerV3``
 - ``TCSigner``
+
 - ``TCSignerError``
 
 ### Credentials

--- a/Sources/TecoSigner/Documentation.docc/index.md
+++ b/Sources/TecoSigner/Documentation.docc/index.md
@@ -20,6 +20,9 @@ It also defines the interface of Tencent Cloud security credentials.
 - ``TCSignerV3``
 - ``TCSigner``
 
+- <doc:SignRequestsV1>
+- ``TCSignerV1``
+
 - ``TCSignerError``
 
 ### Credentials

--- a/Sources/TecoSigner/error.swift
+++ b/Sources/TecoSigner/error.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Errors returned by ``TCSignerV3``.
+/// Errors returned by Teco signers.
 public enum TCSignerError: Error, CustomStringConvertible {
     /// URL provided to the signer is invalid.
     case invalidURL

--- a/Sources/TecoSigner/error.swift
+++ b/Sources/TecoSigner/error.swift
@@ -11,14 +11,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.URL
+/// Errors returned by ``TCSignerV3``.
+public enum TCSignerError: Error, CustomStringConvertible {
+    /// URL provided to the signer is invalid.
+    case invalidURL
 
-/// Tencent Cloud API V3 signer (TC3-HMAC-SHA256).
-@available(*, deprecated, renamed: "TCSignerV3")
-public typealias TCSigner = TCSignerV3
-
-extension TCSignerV3 {
-    /// Process URL before signing.
-    @available(*, deprecated, message: "Make sure the URL is RFC3986 compatible instead.")
-    public func processURL(url: URL) -> URL? { url }
+    /// Human readable description of ``TCSignerError``.
+    public var description: String {
+        switch self {
+        case .invalidURL:
+            return "URL provided to the signer is invalid."
+        }
+    }
 }

--- a/Sources/TecoSigner/signerV1.swift
+++ b/Sources/TecoSigner/signerV1.swift
@@ -41,6 +41,7 @@ public struct TCSignerV1: _SignerSendable {
     ///   - url: Request URL string (RFC 3986).
     ///   - method: Request HTTP method. Defaults to`.GET`.
     ///   - omitSessionToken: Should we include security token in the canonical headers.
+    ///   - nonce: One-time unsigned integer that's used for anti-replay. Defaults to generate randomly.
     ///   - date: Date that URL is valid from, defaults to now.
     /// - Returns: Query string with added "Signature" field that contains request signature.
     /// - Throws: `TCSignerError.invalidURL` if the URL string is malformed.
@@ -48,12 +49,13 @@ public struct TCSignerV1: _SignerSendable {
         url: String,
         method: HTTPMethod = .GET,
         omitSessionToken: Bool = false,
+        nonce: UInt? = nil,
         date: Date = Date()
     ) throws -> String {
         guard let url = URLComponents(string: url), let host = url.host else {
             throw TCSignerError.invalidURL
         }
-        return self.signQueryString(host: host, path: url.path, queryItems: url.queryItems, method: method, omitSessionToken: omitSessionToken, date: date)
+        return self.signQueryString(host: host, path: url.path, queryItems: url.queryItems, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
     }
 
     /// Generate signed query string, for an HTTP request.
@@ -62,6 +64,7 @@ public struct TCSignerV1: _SignerSendable {
     ///   - url: Request URL (RFC 3986).
     ///   - method: Request HTTP method. Defaults to`.GET`.
     ///   - omitSessionToken: Should we include security token in the canonical headers.
+    ///   - nonce: One-time unsigned integer that's used for anti-replay. Defaults to generate randomly.
     ///   - date: Date that URL is valid from, defaults to now.
     /// - Returns: Query string with added "Signature" field that contains request signature.
     /// - Throws: `TCSignerError.invalidURL` if the URL string is malformed.
@@ -69,12 +72,13 @@ public struct TCSignerV1: _SignerSendable {
         url: URL,
         method: HTTPMethod = .GET,
         omitSessionToken: Bool = false,
+        nonce: UInt? = nil,
         date: Date = Date()
     ) throws -> String {
         guard let url = URLComponents(url: url, resolvingAgainstBaseURL: false), let host = url.host else {
             throw TCSignerError.invalidURL
         }
-        return self.signQueryString(host: host, path: url.path, queryItems: url.queryItems, method: method, omitSessionToken: omitSessionToken, date: date)
+        return self.signQueryString(host: host, path: url.path, queryItems: url.queryItems, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
     }
 
     /// Generate signed query string, for an HTTP request.
@@ -84,6 +88,7 @@ public struct TCSignerV1: _SignerSendable {
     ///   - query: Request query string.
     ///   - method: Request HTTP method. Defaults to`.POST`.
     ///   - omitSessionToken: Should we include security token in the canonical headers.
+    ///   - nonce: One-time unsigned integer that's used for anti-replay. Defaults to generate randomly.
     ///   - date: Date that URL is valid from, defaults to now.
     /// - Returns: Query string with added "Signature" field that contains request signature.
     /// - Throws: `TCSignerError.invalidURL` if the URL string is malformed.
@@ -92,6 +97,7 @@ public struct TCSignerV1: _SignerSendable {
         query: String?,
         method: HTTPMethod = .POST,
         omitSessionToken: Bool = false,
+        nonce: UInt? = nil,
         date: Date = Date()
     ) throws -> String {
         guard let url = URL(string: url), let host = url.host else {
@@ -102,7 +108,7 @@ public struct TCSignerV1: _SignerSendable {
             url.query = query
             return url.queryItems
         }()
-        return self.signQueryString(host: host, path: url.path, queryItems: queryItems, method: method, omitSessionToken: omitSessionToken, date: date)
+        return self.signQueryString(host: host, path: url.path, queryItems: queryItems, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
     }
 
     /// Generate signed query string, for an HTTP request.
@@ -112,6 +118,7 @@ public struct TCSignerV1: _SignerSendable {
     ///   - query: Request query string.
     ///   - method: Request HTTP method. Defaults to`.POST`.
     ///   - omitSessionToken: Should we include security token in the canonical headers.
+    ///   - nonce: One-time unsigned integer that's used for anti-replay. Defaults to generate randomly.
     ///   - date: Date that URL is valid from, defaults to now.
     /// - Returns: Query string with added "Signature" field that contains request signature.
     /// - Throws: `TCSignerError.invalidURL` if the URL string is malformed.
@@ -120,6 +127,7 @@ public struct TCSignerV1: _SignerSendable {
         query: String?,
         method: HTTPMethod = .POST,
         omitSessionToken: Bool = false,
+        nonce: UInt? = nil,
         date: Date = Date()
     ) throws -> String {
         guard let host = url.host else {
@@ -130,7 +138,7 @@ public struct TCSignerV1: _SignerSendable {
             url.query = query
             return url.queryItems
         }()
-        return self.signQueryString(host: host, path: url.path, queryItems: queryItems, method: method, omitSessionToken: omitSessionToken, date: date)
+        return self.signQueryString(host: host, path: url.path, queryItems: queryItems, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
     }
 
     /// Generate signed query string, for an HTTP request.
@@ -141,6 +149,7 @@ public struct TCSignerV1: _SignerSendable {
     ///   - query: Request query string.
     ///   - method: Request HTTP method. Defaults to`.GET`.
     ///   - omitSessionToken: Should we include security token in the canonical headers.
+    ///   - nonce: One-time unsigned integer that's used for anti-replay. Defaults to generate randomly.
     ///   - date: Date that URL is valid from, defaults to now.
     /// - Returns: Query string with added "Signature" field that contains request signature.
     /// - Throws: `TCSignerError.invalidURL` if the URL string is malformed.
@@ -150,6 +159,7 @@ public struct TCSignerV1: _SignerSendable {
         query: String?,
         method: HTTPMethod = .GET,
         omitSessionToken: Bool = false,
+        nonce: UInt? = nil,
         date: Date = Date()
     ) -> String {
         let queryItems: [URLQueryItem]? = {
@@ -157,7 +167,7 @@ public struct TCSignerV1: _SignerSendable {
             url.query = query
             return url.queryItems
         }()
-        return self.signQueryString(host: host, path: path, queryItems: queryItems, method: method, omitSessionToken: omitSessionToken, date: date)
+        return self.signQueryString(host: host, path: path, queryItems: queryItems, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
     }
 
     /// Generate signed query string, for an HTTP request.
@@ -168,6 +178,7 @@ public struct TCSignerV1: _SignerSendable {
     ///   - queryItems: Request query items.
     ///   - method: Request HTTP method. Defaults to`.GET`.
     ///   - omitSessionToken: Should we include security token in the canonical headers.
+    ///   - nonce: One-time unsigned integer that's used for anti-replay. Defaults to generate randomly.
     ///   - date: Date that URL is valid from, defaults to now.
     /// - Returns: Query string with added "Signature" field that contains request signature.
     /// - Throws: `TCSignerError.invalidURL` if the URL string is malformed.
@@ -177,13 +188,14 @@ public struct TCSignerV1: _SignerSendable {
         queryItems: [URLQueryItem]?,
         method: HTTPMethod = .GET,
         omitSessionToken: Bool = false,
+        nonce: UInt? = nil,
         date: Date = Date()
     ) -> String {
         var queryItems = queryItems ?? []
 
         // set timestamp and nonce
         queryItems.replaceOrAdd(name: "Timestamp", value: TCSignerV1.timestamp(date))
-        queryItems.replaceOrAdd(name: "Nonce", value: TCSignerV1.nonce())
+        queryItems.replaceOrAdd(name: "Nonce", value: nonce.map(String.init) ?? TCSignerV1.nonce())
 
         // add "SecretId" field
         queryItems.replaceOrAdd(name: "SecretId", value: credential.secretId)

--- a/Sources/TecoSigner/signerV1.swift
+++ b/Sources/TecoSigner/signerV1.swift
@@ -32,6 +32,8 @@ public struct TCSignerV1: _SignerSendable {
         self.credential = credential
     }
 
+    // - MARK: Sign with URL (Defaults to `GET`)
+
     /// Generate signed query string, for an HTTP request.
     ///
     /// - Parameters:
@@ -77,6 +79,8 @@ public struct TCSignerV1: _SignerSendable {
         }
         return self.signQueryString(host: host, path: url.path, queryItems: url.queryItems, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
     }
+
+    // - MARK: Sign with URL and query (Defaults to `POST`)
 
     /// Generate signed query string, for an HTTP request.
     ///
@@ -127,6 +131,58 @@ public struct TCSignerV1: _SignerSendable {
         }
         return self.signQueryString(host: host, path: url.path, query: query, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
     }
+
+    /// Generate signed query string, for an HTTP request.
+    ///
+    /// - Parameters:
+    ///   - url: Request URL (RFC 3986).
+    ///   - queryItems: Request query items.
+    ///   - method: Request HTTP method. Defaults to`.POST`.
+    ///   - omitSessionToken: Should we include security token in the canonical headers.
+    ///   - nonce: One-time unsigned integer that's used for anti-replay. Defaults to generate randomly.
+    ///   - date: Date that URL is valid from, defaults to now.
+    /// - Returns: Query string with added "Signature" field that contains request signature.
+    /// - Throws: `TCSignerError.invalidURL` if the URL string is malformed.
+    public func signQueryString(
+        url: String,
+        queryItems: [URLQueryItem]?,
+        method: HTTPMethod = .POST,
+        omitSessionToken: Bool = false,
+        nonce: UInt? = nil,
+        date: Date = Date()
+    ) throws -> String {
+        guard let url = URLComponents(string: url), let host = url.host else {
+            throw TCSignerError.invalidURL
+        }
+        return self.signQueryString(host: host, path: url.path, queryItems: queryItems, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
+    }
+
+    /// Generate signed query string, for an HTTP request.
+    ///
+    /// - Parameters:
+    ///   - url: Request URL (RFC 3986).
+    ///   - queryItems: Request query items.
+    ///   - method: Request HTTP method. Defaults to`.POST`.
+    ///   - omitSessionToken: Should we include security token in the canonical headers.
+    ///   - nonce: One-time unsigned integer that's used for anti-replay. Defaults to generate randomly.
+    ///   - date: Date that URL is valid from, defaults to now.
+    /// - Returns: Query string with added "Signature" field that contains request signature.
+    /// - Throws: `TCSignerError.invalidURL` if the URL string is malformed.
+    public func signQueryString(
+        url: URL,
+        queryItems: [URLQueryItem]?,
+        method: HTTPMethod = .POST,
+        omitSessionToken: Bool = false,
+        nonce: UInt? = nil,
+        date: Date = Date()
+    ) throws -> String {
+        guard let host = url.host else {
+            throw TCSignerError.invalidURL
+        }
+        return self.signQueryString(host: host, path: url.path, queryItems: queryItems, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
+    }
+
+    // - MARK: Sign with host, path and query (Non-throwing)
 
     /// Generate signed query string, for an HTTP request.
     ///

--- a/Sources/TecoSigner/signerV1.swift
+++ b/Sources/TecoSigner/signerV1.swift
@@ -238,20 +238,20 @@ extension TCSignerV1 {
         }
     }
 
-    /// Stage 3 Calculating signature as in https://cloud.tencent.com/document/api/213/15693#2.4.-.E7.94.9F.E6.88.90.E7.AD.BE.E5.90.8D.E4.B8.B2
+    /// Stage 3 Calculating signature as in https://www.tencentcloud.com/document/api/213/31575#2.4.-generating-a-signature-string
     func signature(signingData: SigningData) -> String {
         let signingSecret = SymmetricKey(data: [UInt8](credential.secretKey.utf8))
-        let signature = HMAC<Insecure.SHA1>.authenticationCode(for: [UInt8](stringToSign(signingData: signingData).utf8), using: signingSecret)
+        let signature = HMAC<Insecure.SHA1>.authenticationCode(for: [UInt8](signatureOriginalString(signingData: signingData).utf8), using: signingSecret)
         return Data(signature).base64EncodedString()
     }
 
-    /// Stage 2 Create the string to sign as in https://cloud.tencent.com/document/api/213/15693#2.3.-.E6.8B.BC.E6.8E.A5.E7.AD.BE.E5.90.8D.E5.8E.9F.E6.96.87.E5.AD.97.E7.AC.A6.E4.B8.B2
-    func stringToSign(signingData: SigningData) -> String {
-        signingData.method.rawValue + signingData.host + signingData.path + "?" + canonicalQueryString(items: signingData.queryItems)
+    /// Stage 2 Create the signature original string as in https://www.tencentcloud.com/document/api/213/31575#2.3.-concatenating-the-signature-original-string
+    func signatureOriginalString(signingData: SigningData) -> String {
+        signingData.method.rawValue + signingData.host + signingData.path + "?" + requestString(items: signingData.queryItems)
     }
 
-    /// Stage 1 Create the canonical query string as in https://cloud.tencent.com/document/api/213/15693#2.1.-.E5.AF.B9.E5.8F.82.E6.95.B0.E6.8E.92.E5.BA.8F and https://cloud.tencent.com/document/api/213/15693#2.2.-.E6.8B.BC.E6.8E.A5.E8.AF.B7.E6.B1.82.E5.AD.97.E7.AC.A6.E4.B8.B2
-    func canonicalQueryString(items: [URLQueryItem]) -> String {
+    /// Stage 1 Create the request string as in https://www.tencentcloud.com/document/api/213/31575#2.1.-sorting-parameters and https://www.tencentcloud.com/document/api/213/31575#2.2.-concatenating-a-request-string
+    func requestString(items: [URLQueryItem]) -> String {
         let queryItems = items.sorted { $0.name < $1.name }
         return queryItems
             .map { "\($0.name)=\($0.value ?? "")" }

--- a/Sources/TecoSigner/signerV1.swift
+++ b/Sources/TecoSigner/signerV1.swift
@@ -11,12 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux) && compiler(>=5.6)
-@preconcurrency import struct Foundation.Data
-#else
-import struct Foundation.Data
-#endif
 import struct Foundation.CharacterSet
+import struct Foundation.Data
 import struct Foundation.Date
 import struct Foundation.URL
 import struct Foundation.URLComponents

--- a/Sources/TecoSigner/signerV1.swift
+++ b/Sources/TecoSigner/signerV1.swift
@@ -1,0 +1,165 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Teco open source project
+//
+// Copyright (c) 2023 the Teco project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Linux) && compiler(>=5.6)
+@preconcurrency import struct Foundation.Data
+#else
+import struct Foundation.Data
+#endif
+import struct Foundation.Date
+import struct Foundation.URL
+import struct Foundation.URLComponents
+import struct Foundation.URLQueryItem
+import enum NIOHTTP1.HTTPMethod
+@_implementationOnly import struct Crypto.HMAC
+@_implementationOnly import enum Crypto.Insecure
+@_implementationOnly import struct Crypto.SymmetricKey
+
+/// Tencent Cloud API V1 signer (HmacSHA1).
+public struct TCSignerV1: _SignerSendable {
+    /// Security credential for accessing Tencent Cloud services.
+    public let credential: Credential
+
+    /// Initialize the signer with Tencent Cloud credential.
+    public init(credential: Credential) {
+        self.credential = credential
+    }
+
+    /// Generate signed query string, for an HTTP request.
+    ///
+    /// - Parameters:
+    ///   - url: Request URL string (RFC 3986).
+    ///   - method: Request HTTP method.
+    ///   - omitSessionToken: Should we include security token in the canonical headers.
+    ///   - date: Date that URL is valid from, defaults to now.
+    /// - Returns: Query string with added "Signature" field that contains request signature.
+    /// - Throws: `TCSignerError.invalidURL` if the URL string is malformed.
+    public func signQueryString(
+        url: String,
+        method: HTTPMethod = .GET,
+        omitSessionToken: Bool = false,
+        date: Date = Date()
+    ) throws -> String {
+        guard let url = URL(string: url) else {
+            throw TCSignerError.invalidURL
+        }
+        return try self.signQueryString(url: url, method: method, omitSessionToken: omitSessionToken, date: date)
+    }
+
+    /// Generate signed query string, for an HTTP request.
+    ///
+    /// - Parameters:
+    ///   - url: Request URL (RFC 3986).
+    ///   - method: Request HTTP method.
+    ///   - omitSessionToken: Should we include security token in the canonical headers.
+    ///   - date: Date that URL is valid from, defaults to now.
+    /// - Returns: Query string with added "Signature" field that contains request signature.
+    /// - Throws: `TCSignerError.invalidURL` if the URL string is malformed.
+    public func signQueryString(
+        url: URL,
+        method: HTTPMethod = .GET,
+        omitSessionToken: Bool = false,
+        date: Date = Date()
+    ) throws -> String {
+        guard let url = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw TCSignerError.invalidURL
+        }
+        var queryItems = url.queryItems ?? []
+
+        // set timestamp and nonce
+        queryItems.replaceOrAdd(name: "Timestamp", value: TCSignerV1.timestamp(date))
+        queryItems.replaceOrAdd(name: "Nonce", value: TCSignerV1.nonce())
+
+        // add "SecretId" field
+        queryItems.replaceOrAdd(name: "SecretId", value: credential.secretId)
+
+        // add session token if available
+        if !omitSessionToken, let sessionToken = credential.token {
+            queryItems.replaceOrAdd(name: "Token", value: sessionToken)
+        }
+
+        // construct signing data. Do this after adding query items as it uses data from them
+        let signingData = SigningData(host: url.host, path: url.path, queryItems: queryItems, method: method)
+
+        // add "Signature" field
+        queryItems.replaceOrAdd(name: "Signature", value: signature(signingData: signingData))
+
+        // now we have signed the request we can add the security token if required
+        if omitSessionToken, let sessionToken = credential.token {
+            queryItems.replaceOrAdd(name: "Token", value: sessionToken)
+        }
+
+        // compose query items into string
+        var composedURL = URLComponents()
+        composedURL.queryItems = queryItems.sorted(by: { $0.name < $1.name })
+        return composedURL.percentEncodedQuery ?? ""
+    }
+}
+
+extension TCSignerV1 {
+    /// structure used to store data used throughout the signing process
+    struct SigningData {
+        let host: String
+        let path: String
+        let queryItems: [URLQueryItem]
+        let method: HTTPMethod
+
+        init(host: String?, path: String, queryItems: [URLQueryItem]?, method: HTTPMethod) {
+            self.host = host ?? ""
+            self.path = path.isEmpty ? "/" : path
+            self.queryItems = queryItems ?? []
+            self.method = method
+        }
+    }
+
+    /// Stage 3 Calculating signature as in https://cloud.tencent.com/document/api/213/15693#2.4.-.E7.94.9F.E6.88.90.E7.AD.BE.E5.90.8D.E4.B8.B2
+    func signature(signingData: SigningData) -> String {
+        let signingSecret = SymmetricKey(data: [UInt8](credential.secretKey.utf8))
+        let signature = HMAC<Insecure.SHA1>.authenticationCode(for: [UInt8](stringToSign(signingData: signingData).utf8), using: signingSecret)
+        return Data(signature).base64EncodedString()
+    }
+
+    /// Stage 2 Create the string to sign as in https://cloud.tencent.com/document/api/213/15693#2.3.-.E6.8B.BC.E6.8E.A5.E7.AD.BE.E5.90.8D.E5.8E.9F.E6.96.87.E5.AD.97.E7.AC.A6.E4.B8.B2
+    func stringToSign(signingData: SigningData) -> String {
+        signingData.method.rawValue + signingData.host + signingData.path + "?" + canonicalQueryString(items: signingData.queryItems)
+    }
+
+    /// Stage 1 Create the canonical query string as in https://cloud.tencent.com/document/api/213/15693#2.1.-.E5.AF.B9.E5.8F.82.E6.95.B0.E6.8E.92.E5.BA.8F and https://cloud.tencent.com/document/api/213/15693#2.2.-.E6.8B.BC.E6.8E.A5.E8.AF.B7.E6.B1.82.E5.AD.97.E7.AC.A6.E4.B8.B2
+    func canonicalQueryString(items: [URLQueryItem]) -> String {
+        let queryItems = items.sorted { $0.name < $1.name }
+        return queryItems
+            .map { "\($0.name)=\($0.value ?? "")" }
+            .joined(separator: "&")
+    }
+
+    /// return a timestamp formatted for signing requests
+    static func timestamp(_ date: Date) -> String {
+        String(UInt64(date.timeIntervalSince1970))
+    }
+
+    /// return a random unsigned integer for request nonce
+    static func nonce() -> String {
+        String(Int32.random(in: 0...Int32.max))
+    }
+}
+
+private extension RangeReplaceableCollection where Self : MutableCollection, Element == URLQueryItem {
+    mutating func replaceOrAdd(name: String, value: String?) {
+        let queryItem = URLQueryItem(name: name, value: value)
+        if let index = self.firstIndex(where: { $0.name == name }) {
+            self[index] = queryItem
+        } else {
+            self.append(queryItem)
+        }
+    }
+}

--- a/Sources/TecoSigner/signerV1.swift
+++ b/Sources/TecoSigner/signerV1.swift
@@ -97,15 +97,10 @@ public struct TCSignerV1: _SignerSendable {
         nonce: UInt? = nil,
         date: Date = Date()
     ) throws -> String {
-        guard let url = URL(string: url), let host = url.host else {
+        guard let url = URLComponents(string: url), let host = url.host else {
             throw TCSignerError.invalidURL
         }
-        let queryItems: [URLQueryItem]? = {
-            var url = URLComponents()
-            url.query = query
-            return url.queryItems
-        }()
-        return self.signQueryString(host: host, path: url.path, queryItems: queryItems, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
+        return self.signQueryString(host: host, path: url.path, query: query, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
     }
 
     /// Generate signed query string, for an HTTP request.
@@ -130,12 +125,7 @@ public struct TCSignerV1: _SignerSendable {
         guard let host = url.host else {
             throw TCSignerError.invalidURL
         }
-        let queryItems: [URLQueryItem]? = {
-            var url = URLComponents()
-            url.query = query
-            return url.queryItems
-        }()
-        return self.signQueryString(host: host, path: url.path, queryItems: queryItems, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
+        return self.signQueryString(host: host, path: url.path, query: query, method: method, omitSessionToken: omitSessionToken, nonce: nonce, date: date)
     }
 
     /// Generate signed query string, for an HTTP request.
@@ -267,18 +257,18 @@ extension TCSignerV1 {
     /// return the query string that is percent encoded properly
     static func percentEncodedQuery(_ queryItems: [URLQueryItem]) -> String {
         queryItems.sorted(by: { $0.name < $1.name })
-            .map { "\($0.name)=\($0.value?.queryEncoded() ?? "")" }
+            .map { "\($0.name)=\($0.value?.queryValueEncoded() ?? "")" }
             .joined(separator: "&")
     }
 }
 
 private extension CharacterSet {
-    static let tcQueryAllowed = CharacterSet.urlQueryAllowed.subtracting(.init(charactersIn: "/;+=&"))
+    static let tcQueryValueAllowed = CharacterSet.urlQueryAllowed.subtracting(.init(charactersIn: "/;+=&"))
 }
 
 private extension String {
-    func queryEncoded() -> String {
-        self.addingPercentEncoding(withAllowedCharacters: .tcQueryAllowed) ?? self
+    func queryValueEncoded() -> String {
+        self.addingPercentEncoding(withAllowedCharacters: .tcQueryValueAllowed) ?? self
     }
 }
 

--- a/Sources/TecoSigner/signerV3.swift
+++ b/Sources/TecoSigner/signerV3.swift
@@ -160,7 +160,7 @@ public struct TCSignerV3: _SignerSendable {
         // construct signing data. Do this after adding the headers as it uses data from the headers
         let signingData = SigningData(url: url, method: method, headers: headers, body: body, bodyHash: bodyHash, timestamp: timestamp, date: dateString, signer: self, minimal: mode == .minimal)
 
-        // construct authorization string as in https://cloud.tencent.com/document/api/213/30654#4.-.E6.8B.BC.E6.8E.A5-Authorization
+        // construct authorization string as in https://www.tencentcloud.com/document/api/213/33224#4.-concatenating-the-authorization
         let authorization = "TC3-HMAC-SHA256 " +
             "Credential=\(credential.secretId)/\(dateString)/\(service)/tc3_request, " +
             "SignedHeaders=\(signingData.signedHeaders), " +
@@ -204,14 +204,14 @@ extension TCSignerV3 {
         }
     }
 
-    /// Stage 3 Calculating signature as in https://cloud.tencent.com/document/api/213/30654#3.-.E8.AE.A1.E7.AE.97.E7.AD.BE.E5.90.8D
+    /// Stage 3 Calculating signature as in https://www.tencentcloud.com/document/api/213/33224#3.-calculating-the-signature
     func signature(signingData: SigningData) -> String {
         let signingSecret = self.signingSecret(date: signingData.date)
         let signature = HMAC<SHA256>.authenticationCode(for: [UInt8](stringToSign(signingData: signingData).utf8), using: signingSecret)
         return signature.hexDigest()
     }
 
-    /// Stage 2 Create the string to sign as in https://cloud.tencent.com/document/api/213/30654#2.-.E6.8B.BC.E6.8E.A5.E5.BE.85.E7.AD.BE.E5.90.8D.E5.AD.97.E7.AC.A6.E4.B8.B2
+    /// Stage 2 Create the string to sign as in https://www.tencentcloud.com/document/api/213/33224#2.-concatenating-the-string-to-be-signed
     func stringToSign(signingData: SigningData) -> String {
         let stringToSign = "TC3-HMAC-SHA256\n" +
             "\(signingData.timestamp)\n" +
@@ -220,7 +220,7 @@ extension TCSignerV3 {
         return stringToSign
     }
 
-    /// Stage 1 Create the canonical request as in https://cloud.tencent.com/document/api/213/30654#1.-.E6.8B.BC.E6.8E.A5.E8.A7.84.E8.8C.83.E8.AF.B7.E6.B1.82.E4.B8.B2
+    /// Stage 1 Create the canonical request as in https://www.tencentcloud.com/document/api/213/33224#1.-concatenating-the-canonicalrequest-string
     func canonicalRequest(signingData: SigningData) -> String {
         let canonicalHeaders = signingData.headers
             .map { "\($0.name):\($0.value)\n" }

--- a/Tests/TecoSignerTests/TCSignerV1Tests.swift
+++ b/Tests/TecoSignerTests/TCSignerV1Tests.swift
@@ -83,12 +83,12 @@ final class TCSignerV1Tests: XCTestCase {
     func testCanonicalRequest() throws {
         let url = URLComponents(string: "https://test.com/?item=apple&hello")!
         let signer = TCSignerV1(credential: credential)
-        let query = signer.canonicalQueryString(items: url.queryItems!)
-        XCTAssertEqual(query, "hello=&item=apple")
+        let requestString = signer.requestString(items: url.queryItems!)
+        XCTAssertEqual(requestString, "hello=&item=apple")
 
         let signingData = TCSignerV1.SigningData(host: url.host, path: url.path, queryItems: url.queryItems, method: .POST)
-        let canonicalString = signer.stringToSign(signingData: signingData)
-        XCTAssertEqual(canonicalString, "POSTtest.com/?hello=&item=apple")
+        let signatureOriginalString = signer.signatureOriginalString(signingData: signingData)
+        XCTAssertEqual(signatureOriginalString, "POSTtest.com/?hello=&item=apple")
     }
 
     // MARK: - Tencent Cloud Signer samples

--- a/Tests/TecoSignerTests/TCSignerV1Tests.swift
+++ b/Tests/TecoSignerTests/TCSignerV1Tests.swift
@@ -51,7 +51,7 @@ final class TCSignerV1Tests: XCTestCase {
         )
     }
 
-    // - MARK: More test cases
+    // - MARK: Special query parameters
 
     func testEmptyQueryParameter() throws {
         let signer = TCSignerV1(credential: credential)
@@ -122,7 +122,7 @@ final class TCSignerV1Tests: XCTestCase {
         XCTAssertEqual(signatureOriginalString, "POSTtest.com/?hello=&item=apple")
     }
 
-    // MARK: - Tencent Cloud Signer samples
+    // MARK: - Tencent Cloud signer samples
 
     // https://cloud.tencent.com/document/api/213/30654
     func testTencentCloudSample() throws {

--- a/Tests/TecoSignerTests/TCSignerV1Tests.swift
+++ b/Tests/TecoSignerTests/TCSignerV1Tests.swift
@@ -80,6 +80,37 @@ final class TCSignerV1Tests: XCTestCase {
         )
     }
 
+    func testUnicodeParameter() throws {
+        let signer = TCSignerV1(credential: credential)
+        let query = signer.signQueryString(
+            host: "tag.tencentcloudapi.com",
+            queryItems: [
+                .init(name: "Action", value: "GetTagValues"),
+                .init(name: "Version", value: "2018-08-13"),
+                .init(name: "TagKeys.0", value: "平台"),
+            ],
+            nonce: 4906,
+            date: Date(timeIntervalSince1970: 1_000_000_000)
+        )
+        XCTAssertEqual(
+            query,
+            "Action=GetTagValues&Nonce=4906&SecretId=MY_TC_SECRET_ID&Signature=UjS7bczn21DgMabt7pq74p7pCVs%3D&TagKeys.0=%E5%B9%B3%E5%8F%B0&Timestamp=1000000000&Version=2018-08-13"
+        )
+    }
+
+    func testPercentEncodedParameter() throws {
+        let signer = TCSignerV1(credential: credential)
+        let query = try signer.signQueryString(
+            url: "https://tag.tencentcloudapi.com/?Action=GetTagValues&Version=2018-08-13&TagKeys.0=%E5%B9%B3%E5%8F%B0",
+            nonce: 4906,
+            date: Date(timeIntervalSince1970: 1_000_000_000)
+        )
+        XCTAssertEqual(
+            query,
+            "Action=GetTagValues&Nonce=4906&SecretId=MY_TC_SECRET_ID&Signature=UjS7bczn21DgMabt7pq74p7pCVs%3D&TagKeys.0=%E5%B9%B3%E5%8F%B0&Timestamp=1000000000&Version=2018-08-13"
+        )
+    }
+
     func testCanonicalRequest() throws {
         let url = URLComponents(string: "https://test.com/?item=apple&hello")!
         let signer = TCSignerV1(credential: credential)

--- a/Tests/TecoSignerTests/TCSignerV1Tests.swift
+++ b/Tests/TecoSignerTests/TCSignerV1Tests.swift
@@ -11,7 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOCore
 import NIOHTTP1
 @testable import TecoSigner
 import XCTest
@@ -82,8 +81,8 @@ final class TCSignerV1Tests: XCTestCase {
 
     func testUnicodeParameter() throws {
         let signer = TCSignerV1(credential: credential)
-        let query = signer.signQueryString(
-            host: "tag.tencentcloudapi.com",
+        let query = try signer.signQueryString(
+            url: "https://tag.tencentcloudapi.com/",
             queryItems: [
                 .init(name: "Action", value: "GetTagValues"),
                 .init(name: "Version", value: "2018-08-13"),
@@ -94,7 +93,7 @@ final class TCSignerV1Tests: XCTestCase {
         )
         XCTAssertEqual(
             query,
-            "Action=GetTagValues&Nonce=4906&SecretId=MY_TC_SECRET_ID&Signature=UjS7bczn21DgMabt7pq74p7pCVs%3D&TagKeys.0=%E5%B9%B3%E5%8F%B0&Timestamp=1000000000&Version=2018-08-13"
+            "Action=GetTagValues&Nonce=4906&SecretId=MY_TC_SECRET_ID&Signature=wC32%2Bfkn0vo3B8Ap0yQEWn0gzFc%3D&TagKeys.0=%E5%B9%B3%E5%8F%B0&Timestamp=1000000000&Version=2018-08-13"
         )
     }
 
@@ -140,6 +139,7 @@ final class TCSignerV1Tests: XCTestCase {
                 .init(name: "Timestamp", value: "1465185768"),
                 .init(name: "Version", value: "2017-03-12"),
             ],
+            method: .GET,
             nonce: 11886,
             date: tcSampleDate
         )

--- a/Tests/TecoSignerTests/TCSignerV1Tests.swift
+++ b/Tests/TecoSignerTests/TCSignerV1Tests.swift
@@ -1,0 +1,120 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Teco open source project
+//
+// Copyright (c) 2023 the Teco project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOHTTP1
+@testable import TecoSigner
+import XCTest
+
+final class TCSignerV1Tests: XCTestCase {
+    let credential: Credential = StaticCredential(secretId: "MY_TC_SECRET_ID", secretKey: "MY_TC_SECRET_KEY")
+    let credentialWithSessionToken: Credential = StaticCredential(secretId: "MY_TC_SECRET_ID", secretKey: "MY_TC_SECRET_KEY", token: "MY_TC_SESSION_TOKEN")
+    let tcSampleCredential: Credential = StaticCredential(secretId: "AKIDz8krbsJ5yKBZQpn74WFkmLPx3*******", secretKey: "Gu5t9xGARNpq86cd98joQYCN3*******")
+    let tcSampleDate: Date = Date(timeIntervalSince1970: 1465185768)
+
+    // - MARK: Examples by API Explorer - https://console.cloud.tencent.com/api/explorer
+
+    func testSignGetRequest() throws {
+        let signer = TCSignerV1(credential: credential)
+        let query = try signer.signQueryString(
+            url: "https://cvm.tencentcloudapi.com/?Action=DescribeInstances&InstanceIds.0=ins-000000&InstanceIds.1=ins-000001&Language=zh-CN&Region=ap-shanghai&Version=2017-03-12",
+            nonce: 8938,
+            date: Date(timeIntervalSince1970: 1_000_000_000)
+        )
+        XCTAssertEqual(
+            query,
+            "Action=DescribeInstances&InstanceIds.0=ins-000000&InstanceIds.1=ins-000001&Language=zh-CN&Nonce=8938&Region=ap-shanghai&SecretId=MY_TC_SECRET_ID&Signature=tJ8iV7prk8YIzmTwwnjVmN9hlTQ%3D&Timestamp=1000000000&Version=2017-03-12"
+        )
+    }
+
+    func testSignPostRequest() throws {
+        let signer = TCSignerV1(credential: credential)
+        let query = try signer.signQueryString(
+            url: "https://cvm.tencentcloudapi.com",
+            query: "Action=DescribeInstances&InstanceIds.0=ins-000000&InstanceIds.1=ins-000001&Language=zh-CN&Region=ap-shanghai&Version=2017-03-12",
+            nonce: 5860,
+            date: Date(timeIntervalSince1970: 1_000_000_000)
+        )
+        XCTAssertEqual(
+            query,
+            "Action=DescribeInstances&InstanceIds.0=ins-000000&InstanceIds.1=ins-000001&Language=zh-CN&Nonce=5860&Region=ap-shanghai&SecretId=MY_TC_SECRET_ID&Signature=ve2J8iIYWjHzJpsAFONELiSMbNA%3D&Timestamp=1000000000&Version=2017-03-12"
+        )
+    }
+
+    // - MARK: More test cases
+
+    func testEmptyQueryParameter() throws {
+        let signer = TCSignerV1(credential: credential)
+        let query = try signer.signQueryString(
+            url: "https://region.tencentcloudapi.com/?Action=DescribeRegions&Product=cvm&Region=&Version=2022-06-27",
+            nonce: 2173,
+            date: Date(timeIntervalSince1970: 1_000_000_000)
+        )
+        XCTAssertEqual(
+            query,
+            "Action=DescribeRegions&Nonce=2173&Product=cvm&Region=&SecretId=MY_TC_SECRET_ID&Signature=hMNWNgTcFjUZB7yVetq2wxeUjzE%3D&Timestamp=1000000000&Version=2022-06-27"
+        )
+    }
+
+    func testLeastParameters() throws {
+        let signer = TCSignerV1(credential: credential)
+        let query = try signer.signQueryString(
+            url: "https://region.tencentcloudapi.com",
+            query: "Action=DescribeProducts&Version=2022-06-27",
+            nonce: 6457,
+            date: Date(timeIntervalSince1970: 1_000_000_000)
+        )
+        XCTAssertEqual(
+            query,
+            "Action=DescribeProducts&Nonce=6457&SecretId=MY_TC_SECRET_ID&Signature=orvrFH0%2FX202yBYL1kDjJ2RG%2Bgo%3D&Timestamp=1000000000&Version=2022-06-27"
+        )
+    }
+
+    func testCanonicalRequest() throws {
+        let url = URLComponents(string: "https://test.com/?item=apple&hello")!
+        let signer = TCSignerV1(credential: credential)
+        let query = signer.canonicalQueryString(items: url.queryItems!)
+        XCTAssertEqual(query, "hello=&item=apple")
+
+        let signingData = TCSignerV1.SigningData(host: url.host, path: url.path, queryItems: url.queryItems, method: .POST)
+        let canonicalString = signer.stringToSign(signingData: signingData)
+        XCTAssertEqual(canonicalString, "POSTtest.com/?hello=&item=apple")
+    }
+
+    // MARK: - Tencent Cloud Signer samples
+
+    // https://cloud.tencent.com/document/api/213/30654
+    func testTencentCloudSample() throws {
+        let signer = TCSignerV1(credential: tcSampleCredential)
+        let query = signer.signQueryString(
+            host: "cvm.tencentcloudapi.com",
+            queryItems: [
+                .init(name: "Action", value: "DescribeInstances"),
+                .init(name: "InstanceIds.0", value: "ins-09dx96dg"),
+                .init(name: "Limit", value: "20"),
+                .init(name: "Nonce", value: "11886"),
+                .init(name: "Offset", value: "0"),
+                .init(name: "Region", value: "ap-guangzhou"),
+                .init(name: "SecretId", value: "AKIDz8krbsJ5yKBZQpn74WFkmLPx3*******"),
+                .init(name: "Timestamp", value: "1465185768"),
+                .init(name: "Version", value: "2017-03-12"),
+            ],
+            nonce: 11886,
+            date: tcSampleDate
+        )
+        XCTAssertEqual(
+            query,
+            "Action=DescribeInstances&InstanceIds.0=ins-09dx96dg&Limit=20&Nonce=11886&Offset=0&Region=ap-guangzhou&SecretId=AKIDz8krbsJ5yKBZQpn74WFkmLPx3*******&Signature=zmmjn35mikh6pM3V7sUEuX4wyYM%3D&Timestamp=1465185768&Version=2017-03-12"
+        )
+    }
+}

--- a/Tests/TecoSignerTests/TCSignerV3Tests.swift
+++ b/Tests/TecoSignerTests/TCSignerV3Tests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Teco open source project
 //
-// Copyright (c) 2022 the Teco project authors
+// Copyright (c) 2022-2023 the Teco project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -26,13 +26,17 @@ import XCTest
     }
 
     public var wrappedValue: Value {
-        guard let value = ProcessInfo.processInfo.environment[variableName] else { return self.defaultValue }
+        guard let value = ProcessInfo.processInfo.environment[variableName] else {
+            return self.defaultValue
+        }
         return Value(value) ?? self.defaultValue
     }
 }
 
-final class TCSignerTests: XCTestCase {
-    @EnvironmentVariable("ENABLE_TIMING_TESTS", default: true) static var enableTimingTests: Bool
+final class TCSignerV3Tests: XCTestCase {
+    @EnvironmentVariable("ENABLE_TIMING_TESTS", default: true)
+    static var enableTimingTests: Bool
+
     let credential: Credential = StaticCredential(secretId: "MY_TC_SECRET_ID", secretKey: "MY_TC_SECRET_KEY")
     let credentialWithSessionToken: Credential = StaticCredential(secretId: "MY_TC_SECRET_ID", secretKey: "MY_TC_SECRET_KEY", token: "MY_TC_SESSION_TOKEN")
     let tcSampleCredential: Credential = StaticCredential(secretId: "AKIDz8krbsJ5yKBZQpn74WFkmLPx3EXAMPLE", secretKey: "Gu5t9xGARNpq86cd98joQYCN3EXAMPLE")
@@ -41,7 +45,7 @@ final class TCSignerTests: XCTestCase {
     // - MARK: Minimal signing by API Explorer - https://console.cloud.tencent.com/api/explorer
 
     func testMinimalSignPostRequest() throws {
-        let signer = TCSigner(credential: credential, service: "cvm")
+        let signer = TCSignerV3(credential: credential, service: "cvm")
         let headers = try signer.signHeaders(
             url: "https://cvm.tencentcloudapi.com",
             method: .POST,
@@ -57,7 +61,7 @@ final class TCSignerTests: XCTestCase {
     }
 
     func testMinimalSignGetRequest() throws {
-        let signer = TCSigner(credential: credential, service: "cvm")
+        let signer = TCSignerV3(credential: credential, service: "cvm")
         let headers = try signer.signHeaders(
             url: "https://cvm.tencentcloudapi.com/?InstanceIds.0=ins-000000&InstanceIds.1=ins-000001",
             method: .GET,
@@ -74,7 +78,7 @@ final class TCSignerTests: XCTestCase {
     // - MARK: Extended Signing
 
     func testSignPostRequest() throws {
-        let signer = TCSigner(credential: credential, service: "region")
+        let signer = TCSignerV3(credential: credential, service: "region")
         let headers = try signer.signHeaders(
             url: "https://region.tencentcloudapi.com",
             method: .POST,
@@ -93,7 +97,7 @@ final class TCSignerTests: XCTestCase {
     }
 
     func testSignGetRequest() throws {
-        let signer = TCSigner(credential: credential, service: "region")
+        let signer = TCSignerV3(credential: credential, service: "region")
         let headers = try signer.signHeaders(
             url: "https://region.tencentcloudapi.com/?Product=cvm",
             method: .GET,
@@ -116,7 +120,7 @@ final class TCSignerTests: XCTestCase {
         var buffer = ByteBufferAllocator().buffer(capacity: data.count)
         buffer.writeBytes(data)
 
-        let signer = TCSigner(credential: credential, service: "cvm")
+        let signer = TCSignerV3(credential: credential, service: "cvm")
         let headers1 = try signer.signHeaders(url: "https://cvm.tencentcloudapi.com", method: .POST, body: .string(string), date: Date(timeIntervalSinceReferenceDate: 0))
         let headers2 = try signer.signHeaders(url: "https://cvm.tencentcloudapi.com", method: .POST, body: .data(data), date: Date(timeIntervalSinceReferenceDate: 0))
         let headers3 = try signer.signHeaders(url: "https://cvm.tencentcloudapi.com", method: .POST, body: .byteBuffer(buffer), date: Date(timeIntervalSinceReferenceDate: 0))
@@ -127,7 +131,7 @@ final class TCSignerTests: XCTestCase {
     }
 
     func testUppercasedHeaderName() throws {
-        let signer = TCSigner(credential: credential, service: "region")
+        let signer = TCSignerV3(credential: credential, service: "region")
         let headers = try signer.signHeaders(
             url: "https://region.tencentcloudapi.com",
             method: .POST,
@@ -147,14 +151,14 @@ final class TCSignerTests: XCTestCase {
 
     func testCanonicalRequest() throws {
         let url = URL(string: "https://test.com/?hello=true&item=apple")!
-        let signer = TCSigner(credential: credential, service: "sns")
-        let signingData = TCSigner.SigningData(
+        let signer = TCSignerV3(credential: credential, service: "sns")
+        let signingData = TCSignerV3.SigningData(
             url: url,
             method: .POST,
             headers: ["content-type": "application/json", "host": "localhost", "User-Agent": "Teco Test"],
             body: .string("{}"),
-            timestamp: TCSigner.timestamp(Date(timeIntervalSince1970: 234_873)),
-            date: TCSigner.dateString(Date(timeIntervalSince1970: 234_873)),
+            timestamp: TCSignerV3.timestamp(Date(timeIntervalSince1970: 234_873)),
+            date: TCSignerV3.dateString(Date(timeIntervalSince1970: 234_873)),
             signer: signer
         )
         let request = signer.canonicalRequest(signingData: signingData)
@@ -172,7 +176,7 @@ final class TCSignerTests: XCTestCase {
     }
 
     func testSkipAuthorization() throws {
-        let signer = TCSigner(credential: credential, service: "cvm")
+        let signer = TCSignerV3(credential: credential, service: "cvm")
         let headers = try signer.signHeaders(
             url: "https://cvm.tencentcloudapi.com/?InstanceIds.0=ins-000000",
             method: .GET,
@@ -187,7 +191,7 @@ final class TCSignerTests: XCTestCase {
 
     // https://cloud.tencent.com/document/api/213/30654
     func testTencentCloudSample() throws {
-        let signer = TCSigner(credential: tcSampleCredential, service: "cvm")
+        let signer = TCSignerV3(credential: tcSampleCredential, service: "cvm")
         let url = URL(string: "https://cvm.tencentcloudapi.com")!
         let headers: HTTPHeaders = [
             "content-type": "application/json; charset=utf-8",
@@ -197,7 +201,7 @@ final class TCSignerTests: XCTestCase {
             "x-tc-version": "2017-03-12",
             "x-tc-region": "ap-guangzhou",
         ]
-        let body: TCSigner.BodyData = .string(#"{"Limit": 1, "Filters": [{"Values": ["\u672a\u547d\u540d"], "Name": "instance-name"}]}"#)
+        let body: TCSignerV3.BodyData = .string(#"{"Limit": 1, "Filters": [{"Values": ["\u672a\u547d\u540d"], "Name": "instance-name"}]}"#)
         let signedHeaders = signer.signHeaders(url: url, method: .POST, headers: headers, body: body, mode: .minimal, date: tcSampleDate)
         XCTAssertEqual(
             signedHeaders["authorization"].first,

--- a/Tests/TecoSignerTests/TCSignerV3Tests.swift
+++ b/Tests/TecoSignerTests/TCSignerV3Tests.swift
@@ -16,27 +16,7 @@ import NIOHTTP1
 @testable import TecoSigner
 import XCTest
 
-@propertyWrapper struct EnvironmentVariable<Value: LosslessStringConvertible> {
-    var defaultValue: Value
-    var variableName: String
-
-    public init(_ variableName: String, default: Value) {
-        self.defaultValue = `default`
-        self.variableName = variableName
-    }
-
-    public var wrappedValue: Value {
-        guard let value = ProcessInfo.processInfo.environment[variableName] else {
-            return self.defaultValue
-        }
-        return Value(value) ?? self.defaultValue
-    }
-}
-
 final class TCSignerV3Tests: XCTestCase {
-    @EnvironmentVariable("ENABLE_TIMING_TESTS", default: true)
-    static var enableTimingTests: Bool
-
     let credential: Credential = StaticCredential(secretId: "MY_TC_SECRET_ID", secretKey: "MY_TC_SECRET_KEY")
     let credentialWithSessionToken: Credential = StaticCredential(secretId: "MY_TC_SECRET_ID", secretKey: "MY_TC_SECRET_KEY", token: "MY_TC_SESSION_TOKEN")
     let tcSampleCredential: Credential = StaticCredential(secretId: "AKIDz8krbsJ5yKBZQpn74WFkmLPx3EXAMPLE", secretKey: "Gu5t9xGARNpq86cd98joQYCN3EXAMPLE")

--- a/Tests/TecoSignerTests/TCSignerV3Tests.swift
+++ b/Tests/TecoSignerTests/TCSignerV3Tests.swift
@@ -55,7 +55,7 @@ final class TCSignerV3Tests: XCTestCase {
         )
     }
 
-    // - MARK: Extended Signing
+    // - MARK: Extended signing
 
     func testSignPostRequest() throws {
         let signer = TCSignerV3(credential: credential, service: "region")
@@ -167,7 +167,7 @@ final class TCSignerV3Tests: XCTestCase {
         XCTAssertEqual(headers["authorization"].first, "SKIP")
     }
 
-    // MARK: - Tencent Cloud Signer samples
+    // MARK: - Tencent Cloud signer samples
 
     // https://cloud.tencent.com/document/api/213/30654
     func testTencentCloudSample() throws {


### PR DESCRIPTION
This PR introduces `TCSignerV1`, using the `HmacSHA1` algorithm, as well as its documentation and unit tests. Accordingly, `TCSigner` is renamed to `TCSignerV3` and its documentation and implementation is slightly improved.