### PR TITLE
Implements support for `HmacSHA256` signing algorithm

### DIFF
--- a/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV1.md
+++ b/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV1.md
@@ -1,4 +1,4 @@
-# Signing API requests with `HmacSHA1` (Unrecommended)
+# Signing API requests with `HmacSHA1` and `HmacSHA256` (Unrecommended)
 
 Generate properly-signed URL query for your Tencent Cloud API request.
 
@@ -6,7 +6,7 @@ Generate properly-signed URL query for your Tencent Cloud API request.
 
 Tencent Cloud API authenticates every single request, i.e., the request must be signed using the security credentials in the designated steps. Each request has to contain the signature information and be sent in the specified way and format.
 
-``TCSignerV1`` makes it easy to sign an API request using the `HmacSHA1` signature algorithm. It may be required for some legacy APIs, but for higher security you should use ``TCSignerV3`` as described in <doc:SignRequestsV3> in the first place.
+``TCSignerV1`` makes it easy to sign an API request using the `HmacSHA1` and `HmacSHA256` signature algorithm. It may be required for some legacy APIs, but for higher security you should use ``TCSignerV3`` as described in <doc:SignRequestsV3> in the first place.
 
 ## Create a signer instance
 
@@ -160,3 +160,13 @@ let signedQueryOmittingToken = try signer.signQueryString(url: url, query omitSe
 ```
 
 You can now use the signed query string as the `POST` request body, and send it to the request URL.
+
+## Use the `HmacSHA256` algorithm
+
+SHA1 is now recognized as an insecure hash function, making `HmacSHA1` unsafe in some situations. `HmacSHA256` is a safer algorithm than `HmacSHA1`, and should be used where applicable.
+
+``TCSignerV1`` has built-in support for the `HmacSHA256` signing algorithm. You can sign a request using `HmacSHA256` by specifying the `algorithm` parameter.
+
+```swift
+let signedQueryWithHmacSHA256 = try signer.signQueryString(url: url, algorithm: .hmacSHA256)
+```

--- a/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV1.md
+++ b/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV1.md
@@ -44,7 +44,7 @@ let url = URL(string: "https://region.tencentcloudapi.com/?Action=DescribeProduc
 
 ### Generate signed query string
 
-You can generate signed query string using ``TCSignerV1/signQueryString(url:method:omitSessionToken:nonce:date:)-91hjz``. The following sample shows a simple signing step using request URL.
+You can generate signed query string using ``TCSignerV1/signQueryString(url:method:algorithm:omitSessionToken:nonce:date:)-9ykb0``. The following sample shows a simple signing step using request URL.
 
 ```swift
 let signedQuery = try signer.signQueryString(url: url)
@@ -67,7 +67,7 @@ let signedQueryWithNonce = signer.signQueryString(
 )
 ```
 
-Note that there are non-throwing variants ``TCSignerV1/signQueryString(host:path:queryItems:method:omitSessionToken:nonce:date:)`` and ``TCSignerV1/signQueryString(host:path:query:method:omitSessionToken:nonce:date:)`` which accepts the request host, path and query directly.
+Note that there are non-throwing variants ``TCSignerV1/signQueryString(host:path:queryItems:method:algorithm:omitSessionToken:nonce:date:)`` and ``TCSignerV1/signQueryString(host:path:query:method:algorithm:omitSessionToken:nonce:date:)`` which accepts the request host, path and query directly.
 
 There are some other configurations to control signing behavior. For example, `omitSessionToken` specifies whether ``Credential/token`` is used for signature.
 
@@ -116,7 +116,7 @@ let query = "Action=DescribeProducts&Version=2022-06-27"
 
 ### Generate signed query string
 
-You can generate signed query string using ``TCSignerV1/signQueryString(url:query:method:omitSessionToken:nonce:date:)-8klqy``. The following sample shows a simple signing step using request URL and body.
+You can generate signed query string using ``TCSignerV1/signQueryString(url:query:method:algorithm:omitSessionToken:nonce:date:)-576vr``. The following sample shows a simple signing step using request URL and body.
 
 ```swift
 let signedQuery = try signer.signQueryString(url: url, query: query)
@@ -139,7 +139,7 @@ let signedQueryWithNonce = try signer.signQueryString(
 )
 ```
 
-Note that the non-throwing variants ``TCSignerV1/signQueryString(host:path:queryItems:method:omitSessionToken:nonce:date:)`` and ``TCSignerV1/signQueryString(host:path:query:method:omitSessionToken:nonce:date:)`` are still available, but you'll have to specify the `method` parameter for a `POST` request.
+Note that the non-throwing variants ``TCSignerV1/signQueryString(host:path:queryItems:method:algorithm:omitSessionToken:nonce:date:)`` and ``TCSignerV1/signQueryString(host:path:query:method:algorithm:omitSessionToken:nonce:date:)`` are still available, but you'll have to specify the `method` parameter for a `POST` request.
 
 ```swift
 let signedHandcraftQuery = signer.signQueryString(

--- a/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV1.md
+++ b/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV1.md
@@ -1,6 +1,6 @@
 # Signing API requests with `HmacSHA1` and `HmacSHA256` (Unrecommended)
 
-Generate properly-signed URL query for your Tencent Cloud API request.
+Generate properly-signed URL query for your Tencent Cloud API request using signature V1.
 
 ## Overview
 
@@ -156,7 +156,7 @@ let signedHandcraftQuery = signer.signQueryString(
 There are some other configurations to control signing behavior. For example, `omitSessionToken` specifies whether ``Credential/token`` is used for signature.
 
 ```swift
-let signedQueryOmittingToken = try signer.signQueryString(url: url, query omitSessionToken: true)
+let signedQueryOmittingToken = try signer.signQueryString(url: url, query: query, omitSessionToken: true)
 ```
 
 You can now use the signed query string as the `POST` request body, and send it to the request URL.

--- a/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV3.md
+++ b/Sources/TecoSigner/Documentation.docc/Guides/SignRequestsV3.md
@@ -1,6 +1,6 @@
 # Signing API requests with `TC3-HMAC-SHA256`
 
-Generate properly-signed HTTP headers for your Tencent Cloud API request.
+Generate properly-signed HTTP headers for your Tencent Cloud API request using signature V3.
 
 ## Overview
 

--- a/Sources/TecoSigner/Documentation.docc/index.md
+++ b/Sources/TecoSigner/Documentation.docc/index.md
@@ -4,11 +4,11 @@
     @DisplayName("Teco Signer")
 }
 
-Signing helpers for Tencent Cloud API signature V3.
+Signing helpers for Tencent Cloud APIs.
 
 ## Overview
 
-This library provides a set of utilities around signing [Tencent Cloud](https://www.tencentcloud.com) API requests using signature V3 (`TC3-HMAC-SHA256`).
+This library provides a set of utilities around signing [Tencent Cloud](https://www.tencentcloud.com) API requests using signature V3 (`TC3-HMAC-SHA256`) and V1 (`HmacSHA1`/`HmacSHA256`).
 
 It also defines the interface of Tencent Cloud security credentials.
 

--- a/Sources/TecoSigner/signerV1.swift
+++ b/Sources/TecoSigner/signerV1.swift
@@ -259,6 +259,7 @@ public struct TCSignerV1: _SignerSendable {
         date: Date = Date()
     ) -> String {
         var queryItems = queryItems ?? []
+        queryItems.remove(name: "Signature")
 
         // set timestamp and nonce
         queryItems.replaceOrAdd(name: "Timestamp", value: TCSignerV1.timestamp(date))
@@ -267,14 +268,18 @@ public struct TCSignerV1: _SignerSendable {
         // add "SecretId" field
         queryItems.replaceOrAdd(name: "SecretId", value: credential.secretId)
 
-        // add "SignatureMethod" field for hmac-sha256
-        if algorithm == .hmacSHA256 {
+        // add "SignatureMethod" field
+        if algorithm != .hmacSHA1 {
             queryItems.replaceOrAdd(name: "SignatureMethod", value: algorithm.rawValue)
+        } else {
+            queryItems.remove(name: "SignatureMethod")
         }
 
         // add session token if available
         if !omitSessionToken, let sessionToken = credential.token {
             queryItems.replaceOrAdd(name: "Token", value: sessionToken)
+        } else {
+            queryItems.remove(name: "Token")
         }
 
         // construct signing data. Do this after adding query items as it uses data from them
@@ -370,5 +375,8 @@ private extension RangeReplaceableCollection where Self : MutableCollection, Ele
         } else {
             self.append(queryItem)
         }
+    }
+    mutating func remove(name: String) {
+        self.removeAll(where: { $0.name == name })
     }
 }

--- a/Sources/TecoSigner/signerV3.swift
+++ b/Sources/TecoSigner/signerV3.swift
@@ -155,6 +155,8 @@ public struct TCSignerV3: _SignerSendable {
         // add session token if available
         if !omitSessionToken, let sessionToken = credential.token {
             headers.replaceOrAdd(name: "x-tc-token", value: sessionToken)
+        } else {
+            headers.remove(name: "x-tc-token")
         }
 
         // construct signing data. Do this after adding the headers as it uses data from the headers

--- a/Tests/TecoSignerTests/TCSignerV1Tests.swift
+++ b/Tests/TecoSignerTests/TCSignerV1Tests.swift
@@ -16,10 +16,15 @@ import NIOHTTP1
 import XCTest
 
 final class TCSignerV1Tests: XCTestCase {
+
     let credential: Credential = StaticCredential(secretId: "MY_TC_SECRET_ID", secretKey: "MY_TC_SECRET_KEY")
     let credentialWithSessionToken: Credential = StaticCredential(secretId: "MY_TC_SECRET_ID", secretKey: "MY_TC_SECRET_KEY", token: "MY_TC_SESSION_TOKEN")
+
     let tcSampleCredential: Credential = StaticCredential(secretId: "AKIDz8krbsJ5yKBZQpn74WFkmLPx3*******", secretKey: "Gu5t9xGARNpq86cd98joQYCN3*******")
     let tcSampleDate: Date = Date(timeIntervalSince1970: 1465185768)
+
+    let tcSHA256SampleCredential: Credential = StaticCredential(secretId: "AKIDT8G5**********ooNq1rFSw1fyBVCX9D", secretKey: "pxPgRWD******qBTDk7WmeRZSmPco0")
+    let tcSHA256SampleDate: Date = Date(timeIntervalSince1970: 1502197934)
 
     // - MARK: Examples by API Explorer - https://console.cloud.tencent.com/api/explorer
 
@@ -146,6 +151,33 @@ final class TCSignerV1Tests: XCTestCase {
         XCTAssertEqual(
             query,
             "Action=DescribeInstances&InstanceIds.0=ins-09dx96dg&Limit=20&Nonce=11886&Offset=0&Region=ap-guangzhou&SecretId=AKIDz8krbsJ5yKBZQpn74WFkmLPx3*******&Signature=zmmjn35mikh6pM3V7sUEuX4wyYM%3D&Timestamp=1465185768&Version=2017-03-12"
+        )
+    }
+
+    // https://cloud.tencent.com/document/api/228/10771
+    func testTencentCloudSHA256Sample() throws {
+        let signer = TCSignerV1(credential: tcSHA256SampleCredential)
+        let query = signer.signQueryString(
+            host: "cdn.api.qcloud.com",
+            path: "/v2/index.php",
+            queryItems: [
+                .init(name: "Action", value: "DescribeCdnHosts"),
+                .init(name: "SecretId", value: "AKIDT8G5**********ooNq1rFSw1fyBVCX9D"),
+                .init(name: "Timestamp", value: "1502197934"),
+                .init(name: "Nonce", value: "48059"),
+                .init(name: "SignatureMethod", value: "HmacSHA256"),
+                .init(name: "offset", value: "0"),
+                .init(name: "limit", value: "10"),
+            ],
+            method: .GET,
+            algorithm: .hmacSHA256,
+            nonce: 48059,
+            date: tcSHA256SampleDate
+        )
+        // This is manually computed since the document is wrong.
+        XCTAssertEqual(
+            query,
+            "Action=DescribeCdnHosts&Nonce=48059&SecretId=AKIDT8G5**********ooNq1rFSw1fyBVCX9D&Signature=8GGNfQ1HXC%2FJkCjUugwXZKtKuMmkbX9lPxtDdkfNxy8%3D&SignatureMethod=HmacSHA256&Timestamp=1502197934&limit=10&offset=0"
         )
     }
 }


### PR DESCRIPTION
This PR adds `HmacSHA256` algorithm support to `TCSignerV1`, and fixes some problems in the documentation. It also addressed a bug where unwanted flags could possibly be counted into signature.