### PR TITLE
Implements support for `multipart/form-data` requests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "multipart-kit",
+        "repositoryURL": "https://github.com/vapor/multipart-kit.git",
+        "state": {
+          "branch": null,
+          "revision": "1adfd69df2da08f7931d4281b257475e32c96734",
+          "version": "4.5.4"
+        }
+      },
+      {
         "package": "swift-atomics",
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -38,6 +39,7 @@ let package = Package(
                 .product(name: "Metrics", package: "swift-metrics"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "MultipartKit", package: "multipart-kit"),
             ]),
         .target(name: "TecoPaginationHelpers",
                 dependencies: ["TecoCore"]),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"2.4.2"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -38,6 +39,7 @@ let package = Package(
                 .product(name: "Metrics", package: "swift-metrics"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "MultipartKit", package: "multipart-kit"),
             ]),
         .target(name: "TecoPaginationHelpers",
                 dependencies: ["TecoCore"]),

--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -278,6 +278,52 @@ extension TCClient {
         )
     }
 
+    /// Execute a request with a multipart-encoded input object and return a future with the output object generated from the response.
+    ///
+    /// - Parameters:
+    ///    - action: Name of the Tencent Cloud action.
+    ///    - path: Path to append to endpoint URL.
+    ///    - region: Region of the service to operate on.
+    ///    - httpMethod: HTTP method to use. Defaults to`.POST`.
+    ///    - serviceConfig: Tencent Cloud service configuration.
+    ///    - skipAuthorization: If "Authorization" header should be set to `SKIP`.
+    ///    - input: API request payload.
+    ///    - logger: Logger to log request details to.
+    ///    - eventLoop: `EventLoop` to run request on.
+    /// - Returns: `EventLoopFuture` containing output object that completes when response is received.
+    public func execute<Input: TCMultipartRequest, Output: TCResponse>(
+        action: String,
+        path: String = "/",
+        region: TCRegion? = nil,
+        httpMethod: HTTPMethod = .POST,
+        serviceConfig: TCServiceConfig,
+        skipAuthorization: Bool = false,
+        input: Input,
+        outputs outputType: Output.Type = Output.self,
+        logger: Logger = TCClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil
+    ) -> EventLoopFuture<Output> {
+        self.execute(
+            action: action,
+            createRequest: try .init(
+                action: action,
+                path: path,
+                region: region,
+                method: httpMethod,
+                input: input,
+                service: serviceConfig
+            ),
+            skipAuthorization: skipAuthorization,
+            executor: { request, eventLoop, logger in
+                self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, logger: logger)
+            },
+            config: serviceConfig,
+            outputType: outputType,
+            logger: logger,
+            on: eventLoop
+        )
+    }
+
     /// Execute a request with empty body and return a future with the output object generated from the response.
     ///
     /// - Parameters:

--- a/Sources/TecoCore/Common/TCModel.swift
+++ b/Sources/TecoCore/Common/TCModel.swift
@@ -25,6 +25,9 @@ public protocol TCOutputModel: TCModel {}
 /// ``TCInputModel`` that serves as request payload.
 public protocol TCRequest: TCInputModel {}
 
+/// ``TCInputModel`` that serves as multi-part request payload.
+public protocol TCMultipartRequest: TCInputModel {}
+
 /// ``TCOutputModel`` that serves as response payload.
 ///
 /// Holds the request ID assigned by Tencent Cloud.

--- a/Sources/TecoCore/Common/TCModel.swift
+++ b/Sources/TecoCore/Common/TCModel.swift
@@ -25,7 +25,7 @@ public protocol TCOutputModel: TCModel {}
 /// ``TCInputModel`` that serves as request payload.
 public protocol TCRequest: TCInputModel {}
 
-/// ``TCInputModel`` that serves as multi-part request payload.
+/// ``TCInputModel`` that serves as Multipart request payload.
 public protocol TCMultipartRequest: TCInputModel {}
 
 /// ``TCOutputModel`` that serves as response payload.

--- a/Sources/TecoCore/Documentation.docc/TCMultipartRequest.md
+++ b/Sources/TecoCore/Documentation.docc/TCMultipartRequest.md
@@ -1,0 +1,7 @@
+# ``TCMultipartRequest``
+
+## Discussions
+
+Some Tencent Cloud APIs have raw binary inputs, which are required to be encoded as `multipart/form-data`.
+
+This doesn't impact the response data format, which should always be JSON.

--- a/Sources/TecoCore/Transport/TCHTTPRequest.swift
+++ b/Sources/TecoCore/Transport/TCHTTPRequest.swift
@@ -27,6 +27,7 @@ import struct Foundation.Data
 import struct Foundation.Date
 import class Foundation.JSONEncoder
 import struct Foundation.URL
+import MultipartKit
 import NIOCore
 import NIOFoundationCompat
 import NIOHTTP1
@@ -85,7 +86,7 @@ extension TCHTTPRequest {
         self.addStandardHeaders()
     }
 
-    internal init<Input: TCInputModel>(
+    internal init<Input: TCRequest>(
         action: String,
         path: String = "/",
         region: TCRegion? = nil,
@@ -111,6 +112,32 @@ extension TCHTTPRequest {
         self.addStandardHeaders()
     }
 
+    internal init<Input: TCMultipartRequest>(
+        action: String,
+        path: String = "/",
+        region: TCRegion? = nil,
+        method: HTTPMethod,
+        input: Input,
+        service: TCServiceConfig
+    ) throws {
+        let body = try FormDataEncoder().encodeAsByteBuffer(input, allocator: service.byteBufferAllocator)
+
+        let endpoint = service.getEndpoint(for: region)
+        guard let url = URL(string: "\(endpoint)\(path)") else {
+            throw TCClient.ClientError.invalidURL
+        }
+
+        self.region = region ?? service.region
+        self.url = url
+        self.method = method
+        self.headers = HTTPHeaders()
+        self.body = body
+
+        // set common parameter headers
+        self.addCommonParameters(action: action, service: service)
+        self.addStandardHeaders(contentType: "multipart/form-data")
+    }
+
     /// Add common header parameters to all requests: "Action", "Version", "Region" and "Language".
     private mutating func addCommonParameters(action: String, service: TCServiceConfig) {
         headers.replaceOrAdd(name: "x-tc-action", value: action)
@@ -124,13 +151,15 @@ extension TCHTTPRequest {
     }
 
     /// Add headers standard to all requests: "content-type" and "user-agent".
-    private mutating func addStandardHeaders() {
+    private mutating func addStandardHeaders(contentType: String? = nil) {
         headers.add(name: "user-agent", value: "Teco/0.1")
 
-        switch method {
-        case .GET:
+        switch (method, contentType) {
+        case (_, .some(let contentType)):
+            headers.replaceOrAdd(name: "content-type", value: contentType)
+        case (.GET, _):
             headers.replaceOrAdd(name: "content-type", value: "application/x-www-form-urlencoded")
-        case .POST:
+        case (.POST, _):
             headers.replaceOrAdd(name: "content-type", value: "application/json")
         default:
             return
@@ -141,5 +170,23 @@ extension TCHTTPRequest {
 extension Credential {
     fileprivate var isEmpty: Bool {
         self.secretId.isEmpty || self.secretKey.isEmpty
+    }
+}
+
+extension FormDataEncoder {
+    /// Writes a Multipart form data representation of the value you supply into a `ByteBuffer` that is freshly allocated.
+    ///
+    /// - Parameters:
+    ///   - value: The value to encode as multipart.
+    ///   - nonce: One-time boundary suffix. Defaults to generate randomly.
+    ///   - allocator: The `ByteBufferAllocator` which is used to allocate the `ByteBuffer` to be returned.
+    /// - Returns: The `ByteBuffer` containing the encoded form data.
+    fileprivate func encodeAsByteBuffer<T: Encodable>(_ value: T, nonce: String? = nil, allocator: ByteBufferAllocator) throws -> ByteBuffer {
+        let nonce = nonce ?? {
+            String((0..<6).compactMap({ _ in "0123456789abcdef".randomElement() }))
+        }()
+        var buffer = allocator.buffer(capacity: 0)
+        try self.encode(value, boundary: "teco-\(nonce)", into: &buffer)
+        return buffer
     }
 }

--- a/Sources/TecoCore/Transport/TCHTTPRequest.swift
+++ b/Sources/TecoCore/Transport/TCHTTPRequest.swift
@@ -27,7 +27,6 @@ import struct Foundation.Data
 import struct Foundation.Date
 import class Foundation.JSONEncoder
 import struct Foundation.URL
-import struct Foundation.URLComponents
 import NIOCore
 import NIOFoundationCompat
 import NIOHTTP1
@@ -97,9 +96,7 @@ extension TCHTTPRequest {
         let body = try JSONEncoder().encodeAsByteBuffer(input, allocator: service.byteBufferAllocator)
 
         let endpoint = service.getEndpoint(for: region)
-        guard let urlComponents = URLComponents(string: "\(endpoint)\(path)"),
-              let url = urlComponents.url
-        else {
+        guard let url = URL(string: "\(endpoint)\(path)") else {
             throw TCClient.ClientError.invalidURL
         }
 

--- a/Sources/TecoCore/Transport/TCHTTPRequest.swift
+++ b/Sources/TecoCore/Transport/TCHTTPRequest.swift
@@ -174,10 +174,10 @@ extension Credential {
 }
 
 extension FormDataEncoder {
-    /// Writes a Multipart form data representation of the value you supply into a `ByteBuffer` that is freshly allocated.
+    /// Writes a Multipart Form Data representation of the value you supply into a `ByteBuffer` that is freshly allocated.
     ///
     /// - Parameters:
-    ///   - value: The value to encode as multipart.
+    ///   - value: The value to encode as Multipart.
     ///   - nonce: One-time boundary suffix. Defaults to generate randomly.
     ///   - allocator: The `ByteBufferAllocator` which is used to allocate the `ByteBuffer` to be returned.
     /// - Returns: The `ByteBuffer` containing the encoded form data.


### PR DESCRIPTION
This PR implements support for encoding API requests as Multipart Form Data. It introduces a new `TCMultipartRequest` protocol, `MultipartKit` dependency, and new APIs built around them.