### PR TITLE
Marks multiple dependencies as implemenation-only

### DIFF
--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -24,11 +24,11 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
-import Atomics
+@_implementationOnly import Atomics
 import Dispatch
 import struct Foundation.URL
 import Logging
-import Metrics
+@_implementationOnly import Metrics
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOHTTP1

--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -29,7 +29,7 @@ import Dispatch
 import struct Foundation.URL
 import Logging
 @_implementationOnly import Metrics
-import NIOConcurrencyHelpers
+@_implementationOnly import NIOConcurrencyHelpers
 import NIOCore
 import NIOHTTP1
 import TecoSigner

--- a/Sources/TecoCore/Credential/CredentialProviderSelector.swift
+++ b/Sources/TecoCore/Credential/CredentialProviderSelector.swift
@@ -24,7 +24,7 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-import NIOConcurrencyHelpers
+@_implementationOnly import NIOConcurrencyHelpers
 import NIOCore
 import TecoSigner
 

--- a/Sources/TecoCore/Credential/DeferredCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/DeferredCredentialProvider.swift
@@ -24,7 +24,7 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-import NIOConcurrencyHelpers
+@_implementationOnly import NIOConcurrencyHelpers
 import NIOCore
 import TecoSigner
 

--- a/Sources/TecoCore/Credential/ProfileCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/ProfileCredentialProvider.swift
@@ -13,7 +13,7 @@
 
 @_implementationOnly import INIParser
 import NIOCore
-import NIOConcurrencyHelpers
+@_implementationOnly import NIOConcurrencyHelpers
 import TecoSigner
 
 /// Credential provider that reads the identity from Tecent Cloud credential profile.

--- a/Sources/TecoCore/Credential/RuntimeSelectorCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/RuntimeSelectorCredentialProvider.swift
@@ -24,7 +24,7 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-import NIOConcurrencyHelpers
+@_implementationOnly import NIOConcurrencyHelpers
 import NIOCore
 import TecoSigner
 

--- a/Sources/TecoCore/Credential/TCCLICredentialProvider.swift
+++ b/Sources/TecoCore/Credential/TCCLICredentialProvider.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-import NIOConcurrencyHelpers
+@_implementationOnly import NIOConcurrencyHelpers
 import NIOCore
 import TecoSigner
 

--- a/Sources/TecoCore/Credential/TemporaryCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/TemporaryCredentialProvider.swift
@@ -25,7 +25,7 @@
 
 import struct Foundation.TimeInterval
 import Logging
-import NIOConcurrencyHelpers
+@_implementationOnly import NIOConcurrencyHelpers
 import NIOCore
 import TecoSigner
 

--- a/Sources/TecoCore/Transport/TCHTTPRequest.swift
+++ b/Sources/TecoCore/Transport/TCHTTPRequest.swift
@@ -27,7 +27,7 @@ import struct Foundation.Data
 import struct Foundation.Date
 import class Foundation.JSONEncoder
 import struct Foundation.URL
-import MultipartKit
+@_implementationOnly import MultipartKit
 import NIOCore
 @_implementationOnly import NIOFoundationCompat
 import NIOHTTP1

--- a/Sources/TecoCore/Transport/TCHTTPRequest.swift
+++ b/Sources/TecoCore/Transport/TCHTTPRequest.swift
@@ -29,7 +29,7 @@ import class Foundation.JSONEncoder
 import struct Foundation.URL
 import MultipartKit
 import NIOCore
-import NIOFoundationCompat
+@_implementationOnly import NIOFoundationCompat
 import NIOHTTP1
 import TecoSigner
 

--- a/Sources/TecoCore/Transport/TCHTTPResponse.swift
+++ b/Sources/TecoCore/Transport/TCHTTPResponse.swift
@@ -27,7 +27,7 @@ import struct Foundation.Data
 import class Foundation.JSONDecoder
 import Logging
 import NIOCore
-import NIOFoundationCompat
+@_implementationOnly import NIOFoundationCompat
 import NIOHTTP1
 
 /// Structure encapsulating a processed HTTP Response.

--- a/Sources/TecoCore/Utils/Environment.swift
+++ b/Sources/TecoCore/Utils/Environment.swift
@@ -13,11 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Glibc)
-import Glibc
+@_implementationOnly import Glibc
 #elseif canImport(CRT)
-import CRT
+@_implementationOnly import CRT
 #elseif canImport(Darwin)
-import Darwin.C
+@_implementationOnly import Darwin.C
 #else
 #error("Unsupported libc.")
 #endif

--- a/Sources/TecoCore/Utils/Environment.swift
+++ b/Sources/TecoCore/Utils/Environment.swift
@@ -14,10 +14,14 @@
 
 #if canImport(Glibc)
 @_implementationOnly import Glibc
-#elseif canImport(CRT)
-@_implementationOnly import CRT
 #elseif canImport(Darwin)
 @_implementationOnly import Darwin.C
+#elseif canImport(CRT)
+@_implementationOnly import CRT
+#elseif canImport(WASILibc)
+@_implementationOnly import WASILibc
+#elseif canImport(Musl)
+@_implementationOnly import Musl
 #else
 #error("Unsupported libc.")
 #endif

--- a/Sources/TecoCore/Utils/FileLoader.swift
+++ b/Sources/TecoCore/Utils/FileLoader.swift
@@ -26,7 +26,7 @@
 import NIOCore
 import NIOPosix
 #if os(Linux)
-import Glibc
+@_implementationOnly import Glibc
 #else
 import Foundation.NSString
 #endif

--- a/Sources/TecoCore/deprecated.swift
+++ b/Sources/TecoCore/deprecated.swift
@@ -14,7 +14,7 @@
 import Foundation
 import Logging
 import NIOCore
-import NIOFoundationCompat
+@_implementationOnly import NIOFoundationCompat
 import NIOHTTP1
 
 /// ``TCInputModel`` that serves as request payload.


### PR DESCRIPTION
This PR marks `Atomics`, `Metrics`, `MultipartKit`, `NIOConcurrencyHelpers`, `NIOFoundationCompat` and all platform modules as `@_implementationOnly`. It also adds support for `WASILibc` and `Musl`.