### PR TITLE
Uses `NIOLockedValueBox` to simplify lock-protected access

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0"),
     ],
     targets: [

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"2.4.2"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0"),
     ],
     targets: [

--- a/Sources/TecoCore/Credential/CredentialProviderSelector.swift
+++ b/Sources/TecoCore/Credential/CredentialProviderSelector.swift
@@ -44,27 +44,11 @@ import TecoSigner
 protocol CredentialProviderSelector: CredentialProvider, AnyObject {
     /// Promise to find a credential provider.
     var startupPromise: EventLoopPromise<CredentialProvider> { get }
-    /// Access lock for ``internalProvider``.
-    var lock: NIOLock { get }
-    /// The storage of ``internalProvider``. **Do not access directly.**
-    var _internalProvider: CredentialProvider? { get set }
+    /// The provider chosen to supply credentials, protected by a `NIOLock`.
+    var internalProvider: NIOLockedValueBox<CredentialProvider?> { get }
 }
 
 extension CredentialProviderSelector {
-    /// The provider chosen to supply credentials.
-    var internalProvider: CredentialProvider? {
-        get {
-            self.lock.withLock {
-                _internalProvider
-            }
-        }
-        set {
-            self.lock.withLock {
-                _internalProvider = newValue
-            }
-        }
-    }
-
     func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
         self.startupPromise.futureResult.flatMap { provider in
             provider.shutdown(on: eventLoop)
@@ -72,7 +56,7 @@ extension CredentialProviderSelector {
     }
 
     func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
-        if let provider = internalProvider {
+        if let provider = internalProvider.withLockedValue({ $0 }) {
             return provider.getCredential(on: eventLoop, logger: logger)
         }
 

--- a/Sources/TecoCore/Credential/DeferredCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/DeferredCredentialProvider.swift
@@ -33,7 +33,7 @@ import TecoSigner
 /// Used for wrapping another credential provider whose `getCredential` method doesn't return instantly and is only needed to be called once.
 ///
 /// After the wrapped ``CredentialProvider`` has generated a credential, it is stored and returned instead of calling the real `getCredential` again.
-public class DeferredCredentialProvider: CredentialProvider {
+public final class DeferredCredentialProvider: CredentialProvider {
     private let provider: CredentialProvider
     private let startupPromise: EventLoopPromise<Credential>
 
@@ -84,8 +84,3 @@ public class DeferredCredentialProvider: CredentialProvider {
 extension DeferredCredentialProvider: CustomStringConvertible {
     public var description: String { "\(type(of: self))(\(provider.description))" }
 }
-
-#if compiler(>=5.6)
-// can use @unchecked Sendable here as 'credential' is a safe 'NIOLockedValueBox'
-extension DeferredCredentialProvider: @unchecked Sendable {}
-#endif

--- a/Sources/TecoCore/Credential/ProfileCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/ProfileCredentialProvider.swift
@@ -110,8 +110,3 @@ extension FileLoader {
         return StaticCredential(secretId: secretId, secretKey: secretKey)
     }
 }
-
-#if compiler(>=5.6)
-// can use @unchecked Sendable here as 'internalProvider' is a safe 'NIOLockedValueBox'
-extension ProfileCredentialProvider: @unchecked Sendable {}
-#endif

--- a/Sources/TecoCore/Credential/RuntimeSelectorCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/RuntimeSelectorCredentialProvider.swift
@@ -31,7 +31,7 @@ import TecoSigner
 /// Get credentials from a list of possible credential providers.
 ///
 /// Goes through the list of providers in order until a credential is supplied, and uses the successful provider.
-class RuntimeSelectorCredentialProvider: CredentialProviderSelector {
+final class RuntimeSelectorCredentialProvider: CredentialProviderSelector {
     /// Promise to find a credential provider.
     let startupPromise: EventLoopPromise<CredentialProvider>
     /// The provider chosen to supply credentials.
@@ -76,8 +76,3 @@ class RuntimeSelectorCredentialProvider: CredentialProviderSelector {
         _setupInternalProvider(0)
     }
 }
-
-#if compiler(>=5.6)
-// can use @unchecked Sendable here as 'internalProvider' is a safe 'NIOLockedValueBox'
-extension RuntimeSelectorCredentialProvider: @unchecked Sendable {}
-#endif

--- a/Sources/TecoCore/Credential/TCCLICredentialProvider.swift
+++ b/Sources/TecoCore/Credential/TCCLICredentialProvider.swift
@@ -114,8 +114,3 @@ private extension FileLoader {
         }
     }
 }
-
-#if compiler(>=5.6)
-// can use @unchecked Sendable here as 'internalProvider' is a safe 'NIOLockedValueBox'
-extension TCCLICredentialProvider: @unchecked Sendable {}
-#endif

--- a/Sources/TecoCore/Credential/TCCLICredentialProvider.swift
+++ b/Sources/TecoCore/Credential/TCCLICredentialProvider.swift
@@ -34,14 +34,13 @@ private struct TCCLICredential: Decodable {
 final class TCCLICredentialProvider: CredentialProviderSelector {
     /// Promise to find a credential provider.
     let startupPromise: EventLoopPromise<CredentialProvider>
-
-    let lock = NIOLock()
-    var _internalProvider: CredentialProvider?
+    /// The provider chosen to supply credentials.
+    let internalProvider = NIOLockedValueBox<CredentialProvider?>(nil)
 
     init(profile: String, context: CredentialProviderFactory.Context, region: TCRegion? = nil) {
         self.startupPromise = context.eventLoop.makePromise(of: CredentialProvider.self)
         self.startupPromise.futureResult.whenSuccess { result in
-            self.internalProvider = result
+            self.internalProvider.withLockedValue { $0 = result }
         }
 
         Self.credentialProvider(from: "~/.tccli/\(profile).credential", context: context, region: region)
@@ -117,7 +116,6 @@ private extension FileLoader {
 }
 
 #if compiler(>=5.6)
-// can use @unchecked Sendable here as `_internalProvider`` is accessed via `internalProvider` which
-// protects access with a `NIOLock`
+// can use @unchecked Sendable here as 'internalProvider' is a safe 'NIOLockedValueBox'
 extension TCCLICredentialProvider: @unchecked Sendable {}
 #endif

--- a/Sources/TecoDateHelpers/Protocols/TCDateValue.swift
+++ b/Sources/TecoDateHelpers/Protocols/TCDateValue.swift
@@ -56,7 +56,7 @@ extension Swift.Optional: TCDateValue where Wrapped == Foundation.Date {
     }
 }
 
-// work around the issue where retroactive Sendable conformance cannot be synthesized by '@preconcurrency'.
 #if os(Linux) && compiler(>=5.6)
+// work around the issue where retroactive Sendable conformance cannot be synthesized by '@preconcurrency'
 extension Foundation.Date: @unchecked Sendable {}
 #endif


### PR DESCRIPTION
This PR changes `NIOLock`-based access to `NIOLockedValueBox` where applicable, which largely simplifies the codes. As a side effect, `swift-nio` version requirement is bumped to v2.42.0.