### PR TITLE
Updates `Sendable` annotations for Swift 5.9

### DIFF
--- a/Sources/TecoCore/Credential/CVMRoleCredentialProvider.swift
+++ b/Sources/TecoCore/Credential/CVMRoleCredentialProvider.swift
@@ -24,7 +24,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
-#if os(Linux) && compiler(>=5.6)
+#if !canImport(Darwin) && compiler(>=5.6)
 @preconcurrency import class Foundation.JSONDecoder
 #else
 import class Foundation.JSONDecoder

--- a/Sources/TecoCore/Credential/ExpiringCredential.swift
+++ b/Sources/TecoCore/Credential/ExpiringCredential.swift
@@ -23,7 +23,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !canImport(Darwin) && compiler(>=5.6) && compiler(<5.9)
+#if !canImport(Darwin) && compiler(>=5.6) && compiler(<5.9.1)
 @preconcurrency import struct Foundation.Date
 #else
 import struct Foundation.Date

--- a/Sources/TecoCore/Credential/ExpiringCredential.swift
+++ b/Sources/TecoCore/Credential/ExpiringCredential.swift
@@ -23,7 +23,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux) && compiler(>=5.6)
+#if os(Linux) && compiler(>=5.6) && compiler(<5.9)
 @preconcurrency import struct Foundation.Date
 #else
 import struct Foundation.Date

--- a/Sources/TecoCore/Credential/ExpiringCredential.swift
+++ b/Sources/TecoCore/Credential/ExpiringCredential.swift
@@ -23,7 +23,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux) && compiler(>=5.6) && compiler(<5.9)
+#if !canImport(Darwin) && compiler(>=5.6) && compiler(<5.9)
 @preconcurrency import struct Foundation.Date
 #else
 import struct Foundation.Date

--- a/Sources/TecoDateHelpers/Protocols/TCDateValue.swift
+++ b/Sources/TecoDateHelpers/Protocols/TCDateValue.swift
@@ -57,6 +57,6 @@ extension Swift.Optional: TCDateValue where Wrapped == Foundation.Date {
 }
 
 // work around the issue where retroactive Sendable conformance cannot be synthesized by '@preconcurrency'.
-#if os(Linux) && compiler(>=5.6) && compiler(<5.9)
+#if !canImport(Darwin) && compiler(>=5.6) && compiler(<5.9)
 extension Foundation.Date: @unchecked Sendable {}
 #endif

--- a/Sources/TecoDateHelpers/Protocols/TCDateValue.swift
+++ b/Sources/TecoDateHelpers/Protocols/TCDateValue.swift
@@ -57,6 +57,6 @@ extension Swift.Optional: TCDateValue where Wrapped == Foundation.Date {
 }
 
 // work around the issue where retroactive Sendable conformance cannot be synthesized by '@preconcurrency'.
-#if os(Linux) && compiler(>=5.6)
+#if os(Linux) && compiler(>=5.6) && compiler(<5.9)
 extension Foundation.Date: @unchecked Sendable {}
 #endif

--- a/Sources/TecoDateHelpers/Protocols/TCDateValue.swift
+++ b/Sources/TecoDateHelpers/Protocols/TCDateValue.swift
@@ -57,6 +57,6 @@ extension Swift.Optional: TCDateValue where Wrapped == Foundation.Date {
 }
 
 // work around the issue where retroactive Sendable conformance cannot be synthesized by '@preconcurrency'.
-#if !canImport(Darwin) && compiler(>=5.6) && compiler(<5.9)
+#if !canImport(Darwin) && compiler(>=5.6) && compiler(<5.9.1)
 extension Foundation.Date: @unchecked Sendable {}
 #endif

--- a/Sources/TecoSigner/signerV3.swift
+++ b/Sources/TecoSigner/signerV3.swift
@@ -23,7 +23,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux) && compiler(>=5.6)
+#if os(Linux) && compiler(>=5.6) && compiler(<5.9)
 @preconcurrency import struct Foundation.Data
 #else
 import struct Foundation.Data

--- a/Sources/TecoSigner/signerV3.swift
+++ b/Sources/TecoSigner/signerV3.swift
@@ -23,7 +23,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux) && compiler(>=5.6) && compiler(<5.9)
+#if !canImport(Darwin) && compiler(>=5.6) && compiler(<5.9)
 @preconcurrency import struct Foundation.Data
 #else
 import struct Foundation.Data


### PR DESCRIPTION
This PR reflects a Swift 5.9 update where `Date`, `DateComponent` and `Data` are marked as `Sendable` in `swift-corelibs-foundation`. It also switches to `!canImport(Darwin)` for identifying platforms with `swift-corelibs-foundation`.