### PR TITLE
Improves `content-type` and `user-agent` header rules

### DIFF
--- a/Sources/TecoCore/Transport/TCHTTPRequest.swift
+++ b/Sources/TecoCore/Transport/TCHTTPRequest.swift
@@ -120,7 +120,11 @@ extension TCHTTPRequest {
         input: Input,
         service: TCServiceConfig
     ) throws {
-        let body = try FormDataEncoder().encodeAsByteBuffer(input, allocator: service.byteBufferAllocator)
+        // compute a random boundary
+        let nonce = String((0..<8).compactMap({ _ in "0123456789abcdef".randomElement() }))
+        let boundary = "teco-\(nonce)"
+
+        let body = try FormDataEncoder().encodeAsByteBuffer(input, boundary: boundary, allocator: service.byteBufferAllocator)
 
         let endpoint = service.getEndpoint(for: region)
         guard let url = URL(string: "\(endpoint)\(path)") else {
@@ -135,7 +139,7 @@ extension TCHTTPRequest {
 
         // set common parameter headers
         self.addCommonParameters(action: action, service: service)
-        self.addStandardHeaders(contentType: "multipart/form-data")
+        self.addStandardHeaders(contentType: "multipart/form-data; boundary=\(boundary)")
     }
 
     /// Add common header parameters to all requests: "Action", "Version", "Region" and "Language".
@@ -170,15 +174,11 @@ extension FormDataEncoder {
     ///
     /// - Parameters:
     ///   - value: The value to encode as Multipart.
-    ///   - nonce: One-time boundary suffix. Defaults to generate randomly.
     ///   - allocator: The `ByteBufferAllocator` which is used to allocate the `ByteBuffer` to be returned.
     /// - Returns: The `ByteBuffer` containing the encoded form data.
-    fileprivate func encodeAsByteBuffer<T: Encodable>(_ value: T, nonce: String? = nil, allocator: ByteBufferAllocator) throws -> ByteBuffer {
-        let nonce = nonce ?? {
-            String((0..<6).compactMap({ _ in "0123456789abcdef".randomElement() }))
-        }()
+    fileprivate func encodeAsByteBuffer<T: Encodable>(_ value: T, boundary: String, allocator: ByteBufferAllocator) throws -> ByteBuffer {
         var buffer = allocator.buffer(capacity: 0)
-        try self.encode(value, boundary: "teco-\(nonce)", into: &buffer)
+        try self.encode(value, boundary: boundary, into: &buffer)
         return buffer
     }
 }

--- a/Sources/TecoCore/Transport/TCHTTPRequest.swift
+++ b/Sources/TecoCore/Transport/TCHTTPRequest.swift
@@ -152,7 +152,7 @@ extension TCHTTPRequest {
 
     /// Add headers standard to all requests: "content-type" and "user-agent".
     private mutating func addStandardHeaders(contentType: String? = nil) {
-        headers.add(name: "user-agent", value: "Teco/0.1")
+        headers.add(name: "user-agent", value: "Teco/0.2")
         if let contentType = contentType {
             headers.replaceOrAdd(name: "content-type", value: contentType)
         }

--- a/Sources/TecoCore/Transport/TCHTTPRequest.swift
+++ b/Sources/TecoCore/Transport/TCHTTPRequest.swift
@@ -109,7 +109,7 @@ extension TCHTTPRequest {
 
         // set common parameter headers
         self.addCommonParameters(action: action, service: service)
-        self.addStandardHeaders()
+        self.addStandardHeaders(contentType: "application/json")
     }
 
     internal init<Input: TCMultipartRequest>(
@@ -153,16 +153,8 @@ extension TCHTTPRequest {
     /// Add headers standard to all requests: "content-type" and "user-agent".
     private mutating func addStandardHeaders(contentType: String? = nil) {
         headers.add(name: "user-agent", value: "Teco/0.1")
-
-        switch (method, contentType) {
-        case (_, .some(let contentType)):
+        if let contentType = contentType {
             headers.replaceOrAdd(name: "content-type", value: contentType)
-        case (.GET, _):
-            headers.replaceOrAdd(name: "content-type", value: "application/x-www-form-urlencoded")
-        case (.POST, _):
-            headers.replaceOrAdd(name: "content-type", value: "application/json")
-        default:
-            return
         }
     }
 }


### PR DESCRIPTION
This PR enforces exact generation for `content-type` on serialization, including the missing `boundary=` for Multipart Form Data. It also updates Teco version in `user-agent`.