### PR TITLE
Moves pagination helpers into Teco Core

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,6 +4,5 @@ builder:
     - documentation_targets:
         - TecoCore
         - TecoDateHelpers
-        - TecoPaginationHelpers
         - TecoSigner
       platform: linux

--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -36,7 +36,7 @@ import TecoSigner
 
 /// Client managing communication with Tencent Cloud services.
 ///
-/// This is the workhorse of TecoCore. You provide it with a ``TCRequest``, it converts it to `TCHTTPRequest` which is then converted to a raw `HTTPClient` request. This is then sent to Tencent Cloud.
+/// This is the workhorse of Teco Core. You provide it with a ``TCRequest``, it converts it to `TCHTTPRequest` which is then converted to a raw `HTTPClient` request. This is then sent to Tencent Cloud.
 ///
 /// When the response from Tencent Cloud is received, it will be converted to a `TCHTTPResponse`, which is then decoded to generate a ``TCResponse`` or to create and throw a ``TCErrorType``.
 public final class TCClient: _TecoSendable {

--- a/Sources/TecoCore/Documentation.docc/TCClient.md
+++ b/Sources/TecoCore/Documentation.docc/TCClient.md
@@ -1,0 +1,56 @@
+# ``TCClient``
+
+## Discussions
+
+Some Tencent Cloud APIs provide query functionality and may return a list of objects with arbitrary length. Most of them come with support for paginating the list, i.e., they will return the list in fixed-size chunks, sometimes also with a token to be used in the next request.
+
+``TCClient`` has integrated support for accessing the full paginated results either synchronously and asynchrously, through pagination and paginator APIs.
+
+## Topics
+
+### Configurating the Client
+
+- ``init(credentialProvider:retryPolicy:options:httpClientProvider:logger:)``
+
+- ``HTTPClientProvider``
+- ``Options``
+
+- ``credentialProvider``
+- ``retryPolicy``
+- ``eventLoopGroup``
+- ``httpClient``
+
+### Executing an API Request
+
+- ``execute(action:path:region:httpMethod:serviceConfig:skipAuthorization:outputs:logger:on:)``
+- ``execute(action:path:region:httpMethod:serviceConfig:skipAuthorization:input:outputs:logger:on:)-1aise``
+- ``execute(action:path:region:httpMethod:serviceConfig:skipAuthorization:input:outputs:logger:on:)-63804``
+
+### Executing a Paginated Request
+
+- ``paginate(input:region:command:initialValue:reducer:logger:on:)``
+- ``paginate(input:region:command:logger:on:)``
+- ``paginate(input:region:command:callback:logger:on:)``
+
+### Retrieving Paginated Results 
+
+- ``Paginator``
+- ``PaginatorSequences``
+- ``Paginator/makeAsyncSequences(input:region:command:logger:on:)``
+
+### Shutting Down the Client
+
+- ``shutdown(queue:_:)``
+- ``syncShutdown()``
+
+### Error Handling
+
+- ``ClientError``
+- ``PaginationError``
+
+### Utilities
+
+- ``loggingDisabled``
+- ``getCredential(on:logger:)``
+- ``signHeaders(url:method:headers:body:serviceConfig:skipAuthorization:logger:)``
+- ``signHeaders(url:httpMethod:headers:body:serviceConfig:skipAuthorization:logger:)``

--- a/Sources/TecoCore/Documentation.docc/TCClient.md
+++ b/Sources/TecoCore/Documentation.docc/TCClient.md
@@ -43,11 +43,6 @@ Some Tencent Cloud APIs provide query functionality and may return a list of obj
 - ``shutdown(queue:_:)``
 - ``syncShutdown()``
 
-### Error Handling
-
-- ``ClientError``
-- ``PaginationError``
-
 ### Utilities
 
 - ``loggingDisabled``

--- a/Sources/TecoCore/Documentation.docc/TCPaginatedResponse.md
+++ b/Sources/TecoCore/Documentation.docc/TCPaginatedResponse.md
@@ -1,4 +1,4 @@
-# ``TecoPaginationHelpers/TCPaginatedResponse``
+# ``TCPaginatedResponse``
 
 ## Discussion
 

--- a/Sources/TecoCore/Documentation.docc/TCPaginatedResponse/Count.md
+++ b/Sources/TecoCore/Documentation.docc/TCPaginatedResponse/Count.md
@@ -1,0 +1,7 @@
+# ``TCPaginatedResponse/Count``
+
+## Discussion
+
+Most paginated Tencent Cloud APIs return the total element count for the queried items in a `BinaryInteger`, eg. `UInt64`. We use this value to ensure the queried result didn't change during pagination, and will throw a ``TCClient/PaginationError/totalCountChanged`` error if it changed unexpectedly.
+
+Some paginated API responses, however, doesn't have a total count field. For these response models, ``Count`` should be `Never` and ``getTotalCount()-6kxsn`` will always return `nil`.

--- a/Sources/TecoCore/Documentation.docc/index.md
+++ b/Sources/TecoCore/Documentation.docc/index.md
@@ -34,9 +34,13 @@ This library provides most common functionalities around calling Tencent Cloud A
 - ``TCOutputModel``
 
 - ``TCRequest``
-- ``TCRequestModel``
+- ``TCMultipartRequest``
+- ``TCPaginatedRequest``
 
 - ``TCResponse``
+- ``TCPaginatedResponse``
+
+- ``TCRequestModel``
 - ``TCResponseModel``
 
 ### Credentials
@@ -66,7 +70,7 @@ This library provides most common functionalities around calling Tencent Cloud A
 - ``EndpointProvider``
 - ``EndpointProviderFactory``
 
-### Error handling
+### Error Handling
 
 - ``TCErrorContext``
 

--- a/Sources/TecoCore/Documentation.docc/index.md
+++ b/Sources/TecoCore/Documentation.docc/index.md
@@ -72,6 +72,9 @@ This library provides most common functionalities around calling Tencent Cloud A
 
 ### Error Handling
 
+- ``TCClient/ClientError``
+- ``TCClient/PaginationError``
+
 - ``TCErrorContext``
 
 - ``TCErrorType``

--- a/Sources/TecoCore/Pagination/TCClient+Pagination.swift
+++ b/Sources/TecoCore/Pagination/TCClient+Pagination.swift
@@ -13,7 +13,6 @@
 
 import NIOCore
 import Logging
-import TecoCore
 
 extension TCClient {
     /// Execute a series of paginated requests and return a future with the combined result generated from the responses.

--- a/Sources/TecoCore/Pagination/TCClient+PaginationError.swift
+++ b/Sources/TecoCore/Pagination/TCClient+PaginationError.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 extension TCClient {
-    /// Errors returned by `TCClient` pagination helpers.
+    /// Errors returned by ``TCClient`` pagination helpers.
     public enum PaginationError: Error, Equatable {
         /// Total item count changed during pagination.
         case totalCountChanged

--- a/Sources/TecoCore/Pagination/TCClient+PaginationError.swift
+++ b/Sources/TecoCore/Pagination/TCClient+PaginationError.swift
@@ -11,8 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TecoCore
-
 extension TCClient {
     /// Errors returned by `TCClient` pagination helpers.
     public enum PaginationError: Error, Equatable {

--- a/Sources/TecoCore/Pagination/TCClient+Paginator.swift
+++ b/Sources/TecoCore/Pagination/TCClient+Paginator.swift
@@ -13,7 +13,6 @@
 
 import Logging
 import NIOCore
-import TecoCore
 
 extension TCClient {
     /// Tuple consisting of async sequences returned by the paginator.

--- a/Sources/TecoCore/Pagination/TCPaginatedModel.swift
+++ b/Sources/TecoCore/Pagination/TCPaginatedModel.swift
@@ -11,14 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TecoCore
-
-#if swift(>=5.6)
-public typealias _PaginationSendable = Sendable
-#else
-public typealias _PaginationSendable = Any
-#endif
-
 /// Tencent Cloud API request model that represents a paginated query.
 public protocol TCPaginatedRequest: TCRequest {
     /// Paginated response type associated with the request.
@@ -31,9 +23,9 @@ public protocol TCPaginatedRequest: TCRequest {
 /// Tencent Cloud API response model that contains a list of paginated result and a total count.
 public protocol TCPaginatedResponse: TCResponse {
     /// The total count type to be extracted from the response.
-    associatedtype Count: _PaginationSendable, Equatable
+    associatedtype Count: _TecoSendable, Equatable
     /// The queried item type.
-    associatedtype Item: _PaginationSendable
+    associatedtype Item: _TecoSendable
 
     /// Extract the total count from the paginated response.
     func getTotalCount() -> Count?

--- a/Sources/TecoCore/Pagination/TCPaginatedModel.swift
+++ b/Sources/TecoCore/Pagination/TCPaginatedModel.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Tencent Cloud API request model that represents a paginated query.
+/// ``TCRequest`` that represents a paginated query.
 public protocol TCPaginatedRequest: TCRequest {
     /// Paginated response type associated with the request.
     associatedtype Response: TCPaginatedResponse
@@ -20,7 +20,7 @@ public protocol TCPaginatedRequest: TCRequest {
     func makeNextRequest(with response: Response) -> Self?
 }
 
-/// Tencent Cloud API response model that contains a list of paginated result and a total count.
+/// ``TCResponse`` that contains a list of paginated result and a total count.
 public protocol TCPaginatedResponse: TCResponse {
     /// The total count type to be extracted from the response.
     associatedtype Count: _TecoSendable, Equatable

--- a/Sources/TecoPaginationHelpers/Documentation.docc/TCPaginatedResponse/Count.md
+++ b/Sources/TecoPaginationHelpers/Documentation.docc/TCPaginatedResponse/Count.md
@@ -1,7 +1,0 @@
-# ``TecoPaginationHelpers/TCPaginatedResponse/Count``
-
-## Discussion
-
-Most paginated Tencent Cloud APIs return the total element count for the queried items in a `BinaryInteger`, eg. `UInt64`. We use this value to ensure the queried result didn't change during pagination, and will throw a ``TecoPaginationHelpers/TecoCore/TCClient/PaginationError/totalCountChanged`` error if it changed unexpectedly.
-
-Some paginated API responses, however, doesn't have a total count field. For these response models, ``Count`` should be `Never` and ``getTotalCount()-9zl99`` will always return `nil`.

--- a/Sources/TecoPaginationHelpers/Documentation.docc/index.md
+++ b/Sources/TecoPaginationHelpers/Documentation.docc/index.md
@@ -6,6 +6,6 @@
 
 Pagination support for Tencent Cloud APIs.
 
-## Overview
+## Discussions
 
-This module has been deprecated and all functionalities were moved into `TecoCore`.
+This module has been deprecated and all functionalities were moved into Teco Core.

--- a/Sources/TecoPaginationHelpers/Documentation.docc/index.md
+++ b/Sources/TecoPaginationHelpers/Documentation.docc/index.md
@@ -1,34 +1,11 @@
 # ``TecoPaginationHelpers``
 
 @Metadata {
-    @DisplayName("Teco Pagination Helpers")
+    @DisplayName("Teco Pagination Helpers (Deprecated)")
 }
 
 Pagination support for Tencent Cloud APIs.
 
 ## Overview
 
-Some Tencent Cloud APIs provide query functionality and may return a list of objects with arbitrary length. Most of them come with support for paginating the list, i.e., they will return the list in fixed-size chunks, sometimes also with a token to be used in the next request.
-
-This module provides helpers for accessing the full paginated result either synchronously and asynchrously with `Teco`.
-
-## Topics
-
-### Models
-
-- ``TCPaginatedRequest``
-- ``TCPaginatedResponse``
-
-- ``TecoCore/TCClient/PaginationError``
-
-### Pagination
-
-- ``TecoCore/TCClient/paginate(input:region:command:initialValue:reducer:logger:on:)``
-- ``TecoCore/TCClient/paginate(input:region:command:logger:on:)``
-- ``TecoCore/TCClient/paginate(input:region:command:callback:logger:on:)``
-
-### Paginator
-
-- ``TecoCore/TCClient/Paginator``
-- ``TecoCore/TCClient/PaginatorSequences``
-- ``TecoCore/TCClient/Paginator/makeAsyncSequences(input:region:command:logger:on:)``
+This module has been deprecated and all functionalities were moved into `TecoCore`.

--- a/Sources/TecoPaginationHelpers/deprecated.swift
+++ b/Sources/TecoPaginationHelpers/deprecated.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Teco open source project
+//
+// Copyright (c) 2023 the Teco project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import TecoCore
+
+#if swift(>=5.6)
+public typealias _PaginationSendable = Sendable
+#else
+public typealias _PaginationSendable = Any
+#endif


### PR DESCRIPTION
This PR merges pagination support into Teco Core, making `TecoPaginationHelpers` a shell of `TecoCore`. It also removes `TecoPaginationHelpers` from SPI documentation targets, and updates the documentation accordingly.

Fixes #11.