### PR TITLE
Migrates `AsyncHTTPClient` to use NIO singleton

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "78db67e5bf4a8543075787f228e8920097319281",
-          "version": "1.18.0"
+          "revision": "16f7e62c08c6969899ce6cc277041e868364e5cf",
+          "version": "1.19.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "6213ba7a06febe8fef60563a4a7d26a4085783cf",
-          "version": "2.54.0"
+          "revision": "3db5c4aeee8100d2db6f1eaf3864afdad5dc68fd",
+          "version": "2.59.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "41f4098903878418537020075a4d8a6e20a0b182",
-          "version": "1.17.0"
+          "revision": "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
+          "version": "1.19.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.4.1"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.4.1"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.14.1"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),

--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -1,0 +1,58 @@
+// swift-tools-version: 5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "teco-core",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+       .library(
+           name: "TecoCore",
+           targets: ["TecoCore", "TecoDateHelpers", "TecoPaginationHelpers"]),
+       .library(
+           name: "TecoSigner",
+           targets: ["TecoSigner"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.14.1"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", "2.42.0"..<"2.55.0"),
+        .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "TecoCore",
+            dependencies: [
+                .byName(name: "INIParser"),
+                .byName(name: "TecoSigner"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "Atomics", package: "swift-atomics"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Metrics", package: "swift-metrics"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "MultipartKit", package: "multipart-kit"),
+            ]),
+        .target(name: "TecoPaginationHelpers",
+                dependencies: ["TecoCore"]),
+        .target(name: "TecoDateHelpers"),
+        .target(name: "INIParser"),
+        .target(
+            name: "TecoSigner",
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+            ]),
+        .testTarget(
+            name: "TecoSignerTests",
+            dependencies: ["TecoSigner"]),
+    ]
+)

--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -88,9 +88,13 @@ public final class TCClient: _TecoSendable {
         case .shared(let httpClient):
             self.httpClient = httpClient
         case .createNewWithEventLoopGroup(let eventLoopGroup):
-            self.httpClient = HTTPClient(eventLoopGroup: eventLoopGroup, configuration: .init(timeout: .init(connect: .seconds(10))))
+            self.httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup), configuration: .init(timeout: .init(connect: .seconds(10))))
         case .createNew:
+            #if swift(>=5.6)
             self.httpClient = HTTPClient(eventLoopGroupProvider: .singleton, configuration: .init(timeout: .init(connect: .seconds(10))))
+            #else
+            self.httpClient = HTTPClient(eventLoopGroupProvider: .createNew, configuration: .init(timeout: .init(connect: .seconds(10))))
+            #endif
         }
 
         self.credentialProvider = credentialProviderFactory.createProvider(context: .init(

--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -90,7 +90,7 @@ public final class TCClient: _TecoSendable {
         case .createNewWithEventLoopGroup(let eventLoopGroup):
             self.httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup), configuration: .init(timeout: .init(connect: .seconds(10))))
         case .createNew:
-            #if swift(>=5.6)
+            #if swift(>=5.7)
             self.httpClient = HTTPClient(eventLoopGroupProvider: .singleton, configuration: .init(timeout: .init(connect: .seconds(10))))
             #else
             self.httpClient = HTTPClient(eventLoopGroupProvider: .createNew, configuration: .init(timeout: .init(connect: .seconds(10))))

--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -74,13 +74,13 @@ public final class TCClient: _TecoSendable {
     ///    - credentialProvider: An object that returns valid signing credentials for request signing.
     ///    - retryPolicy: An object that tells what to do when a request fails.
     ///    - options: Client configurations.
-    ///    - httpClientProvider: `HTTPClient` to use. Use `.createNew` if you want the client to manage its own `HTTPClient`.
+    ///    - httpClientProvider: `HTTPClient` to use. Defaults to `.createNew`.
     ///    - logger: Logger used to log background `TCClient` events.
     public init(
         credentialProvider credentialProviderFactory: CredentialProviderFactory = .default,
         retryPolicy retryPolicyFactory: RetryPolicyFactory = .default,
         options: Options = Options(),
-        httpClientProvider: HTTPClientProvider,
+        httpClientProvider: HTTPClientProvider = .createNew,
         logger clientLogger: Logger = TCClient.loggingDisabled
     ) {
         self.httpClientProvider = httpClientProvider

--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -188,11 +188,11 @@ public final class TCClient: _TecoSendable {
         ///
         /// The user should be responsible for the lifecycle of the `HTTPClient`.
         case shared(HTTPClient)
-        /// `HTTPClient` will be created by `TCClient` using provided `EventLoopGroup`.
+        /// `HTTPClient` will be created by `TCClient` using the provided `EventLoopGroup`.
         ///
         /// When `shutdown` is called, created `HTTPClient` will be shut down as well.
         case createNewWithEventLoopGroup(EventLoopGroup)
-        /// `HTTPClient` will be created by `TCClient` using `NIOSingleton`.
+        /// `HTTPClient` will be created by `TCClient` using `NIOSingletons`.
         ///
         /// When `shutdown` is called, created `HTTPClient` will be shut down as well.
         case createNew


### PR DESCRIPTION
NIO singleton largely lowers the cost to create a new HTTP client. With the adoption of the feature, we also added `.createNew` as the default `HTTPClientProvider` for `TCClient`, making it available with no required arguments.

As a consequence, the requirement for `swift-server/async-http-client` is bumped to v1.19.0 and `apple/swift-nio` to v2.58.0. Swift 5.5 and 5.6 support is restricted due to regressions from dependencies.