### PR TITLE
Introduces a globally shared `TCClient`

### DIFF
--- a/Sources/TecoCore/Common/TCClient.swift
+++ b/Sources/TecoCore/Common/TCClient.swift
@@ -63,7 +63,7 @@ public final class TCClient: _TecoSendable {
     private let signingMode: TCSignerV3.SigningMode
     /// Custom client options.
     private let options: Options
-    /// If the client can be shutdown.
+    /// If the client can be shut down.
     private let canBeShutdown: Bool
     /// Holds the client shutdown state.
     private let isShutdown = ManagedAtomic<Bool>(false)
@@ -135,14 +135,14 @@ public final class TCClient: _TecoSendable {
         assert(self.isShutdown.load(ordering: .relaxed), "TCClient not shut down before the deinit. Please call client.syncShutdown() when no longer needed.")
     }
 
-    // MARK: Shutdown
+    // MARK: Shut down
 
-    /// Shutdown the client synchronously.
+    /// Shut down the client synchronously.
     ///
     /// Before a `TCClient` is deleted, you need to call this function or the async version ``shutdown(queue:_:)`` to do a clean shutdown of the client.
     /// It cleans up ``CredentialProvider`` tasks and shuts down the HTTP client if it was created by the `TCClient`.
     ///
-    /// - Throws: `ClientError.alreadyShutdown`: You have already shutdown the client.
+    /// - Throws: `ClientError.alreadyShutdown`: You have already shut down the client.
     public func syncShutdown() throws {
         let errorStorage = NIOLockedValueBox<Error?>(nil)
         let continuation = DispatchWorkItem {}
@@ -160,7 +160,7 @@ public final class TCClient: _TecoSendable {
         }
     }
 
-    /// Shutdown the client asynchronously.
+    /// Shut down the client asynchronously.
     ///
     /// Before a `TCClient` is deleted, you need to call this function or the synchronous version ``syncShutdown()`` to do a clean shutdown of the client.
     /// It cleans up ``CredentialProvider`` tasks and shuts down the HTTP client if it was created by the `TCClient`.

--- a/Sources/TecoCore/Credential/CredentialProvider.swift
+++ b/Sources/TecoCore/Credential/CredentialProvider.swift
@@ -36,7 +36,7 @@ public protocol CredentialProvider: CustomStringConvertible, _TecoSendable {
     ///   - logger: Logger to use.
     func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential>
 
-    /// Shutdown the credential provider.
+    /// Shut down the credential provider.
     ///
     /// - Parameter eventLoop: `Eventloop` to use when shutting down.
     func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void>

--- a/Sources/TecoCore/Credential/CredentialProviderWithClient.swift
+++ b/Sources/TecoCore/Credential/CredentialProviderWithClient.swift
@@ -19,7 +19,7 @@ protocol CredentialProviderWithClient: CredentialProvider {
 }
 
 extension CredentialProviderWithClient {
-    /// Shutdown credential provider and its client.
+    /// Shut down the credential provider and its client.
     func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
         let promise = eventLoop.makePromise(of: Void.self)
         client.shutdown { error in

--- a/Sources/TecoCore/Utils/FileLoader.swift
+++ b/Sources/TecoCore/Utils/FileLoader.swift
@@ -51,7 +51,7 @@ enum FileLoader {
         return self.loadFile(path: path, on: eventLoop, using: fileIO)
             .flatMap(callback)
             .always { _ in
-                // shutdown the threadpool async
+                // shut down the threadpool async
                 threadPool.shutdownGracefully { _ in }
             }
     }

--- a/Sources/TecoCore/Utils/Singleton.swift
+++ b/Sources/TecoCore/Utils/Singleton.swift
@@ -21,6 +21,13 @@ extension TCClient {
 }
 
 private let globallySharedTCClient: TCClient = {
-    let client = TCClient(logger: TCClient.loggingDisabled)
+    let client = TCClient(
+        credentialProvider: .default,
+        retryPolicy: .default,
+        options: .init(),
+        httpClientProvider: .createNew,
+        canBeShutdown: false,
+        logger: TCClient.loggingDisabled
+    )
     return client
 }()

--- a/Sources/TecoCore/Utils/Singleton.swift
+++ b/Sources/TecoCore/Utils/Singleton.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Teco open source project
+//
+// Copyright (c) 2023 the Teco project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension TCClient {
+    /// A globally shared, singleton ``TCClient``.
+    ///
+    /// This shared client instance uses a singleton `EventLoopGroup` and cannot be shut down.
+    public static var shared: TCClient {
+        globallySharedTCClient
+    }
+}
+
+private let globallySharedTCClient: TCClient = {
+    let client = TCClient(logger: TCClient.loggingDisabled)
+    return client
+}()


### PR DESCRIPTION
This PR introduces a global `TCClient.shared` to ease the use, preventing users from creating multiple `TCClient`s unnecessarily.