### PR TITLE
Updates `TCDateWrapper` internals to use SPI

### DIFF
--- a/Sources/TecoDateHelpers/Property Wrappers/TCDateEncoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCDateEncoding.swift
@@ -51,7 +51,7 @@ public struct TCDateEncoding<WrappedValue: TCDateValue>: Codable {
 }
 
 extension TCDateEncoding: TCDateWrapper {
-    @_spi(_TecoInternals) public static var _valueDescription: String {
+    @_spi(_TecoInternals) public static var _valueDescription: StaticString {
         "date"
     }
 

--- a/Sources/TecoDateHelpers/Property Wrappers/TCDateEncoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCDateEncoding.swift
@@ -51,11 +51,11 @@ public struct TCDateEncoding<WrappedValue: TCDateValue>: Codable {
 }
 
 extension TCDateEncoding: TCDateWrapper {
-    public static var _valueDescription: String {
+    @_spi(_TecoInternals) public static var _valueDescription: String {
         "date"
     }
 
-    public static var _formatter: DateFormatter {
+    @_spi(_TecoInternals) public static var _formatter: DateFormatter {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"

--- a/Sources/TecoDateHelpers/Property Wrappers/TCTimestampEncoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCTimestampEncoding.swift
@@ -51,7 +51,7 @@ public struct TCTimestampEncoding<WrappedValue: TCDateValue>: Codable {
 }
 
 extension TCTimestampEncoding: TCDateWrapper {
-    @_spi(_TecoInternals) public static var _valueDescription: String {
+    @_spi(_TecoInternals) public static var _valueDescription: StaticString {
         "timestamp"
     }
 

--- a/Sources/TecoDateHelpers/Property Wrappers/TCTimestampEncoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCTimestampEncoding.swift
@@ -51,11 +51,11 @@ public struct TCTimestampEncoding<WrappedValue: TCDateValue>: Codable {
 }
 
 extension TCTimestampEncoding: TCDateWrapper {
-    public static var _valueDescription: String {
+    @_spi(_TecoInternals) public static var _valueDescription: String {
         "timestamp"
     }
 
-    public static var _formatter: DateFormatter {
+    @_spi(_TecoInternals) public static var _formatter: DateFormatter {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"

--- a/Sources/TecoDateHelpers/Property Wrappers/TCTimestampISO8601Encoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCTimestampISO8601Encoding.swift
@@ -49,11 +49,11 @@ public struct TCTimestampISO8601Encoding<WrappedValue: TCDateValue>: Codable {
 }
 
 extension TCTimestampISO8601Encoding: TCDateWrapper {
-    public static var _valueDescription: String {
+    @_spi(_TecoInternals) public static var _valueDescription: String {
         "timestamp"
     }
 
-    public static var _formatter: ISO8601DateFormatter {
+    @_spi(_TecoInternals) public static var _formatter: ISO8601DateFormatter {
         ISO8601DateFormatter()
     }
 }

--- a/Sources/TecoDateHelpers/Property Wrappers/TCTimestampISO8601Encoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCTimestampISO8601Encoding.swift
@@ -49,7 +49,7 @@ public struct TCTimestampISO8601Encoding<WrappedValue: TCDateValue>: Codable {
 }
 
 extension TCTimestampISO8601Encoding: TCDateWrapper {
-    @_spi(_TecoInternals) public static var _valueDescription: String {
+    @_spi(_TecoInternals) public static var _valueDescription: StaticString {
         "timestamp"
     }
 

--- a/Sources/TecoDateHelpers/Protocols/TCDateWrapper.swift
+++ b/Sources/TecoDateHelpers/Protocols/TCDateWrapper.swift
@@ -13,15 +13,15 @@
 
 public protocol TCDateWrapper: Codable, _TecoDateSendable {
     associatedtype WrappedValue: TCDateValue
-    associatedtype _Formatter: TCDateFormatter
+    associatedtype Formatter: TCDateFormatter
 
     var wrappedValue: WrappedValue { get }
     var projectedValue: StorageValue { get }
 
     init(wrappedValue: WrappedValue)
 
-    static var _formatter: _Formatter { get }
-    static var _valueDescription: String { get }
+    @_spi(_TecoInternals) static var _formatter: Formatter { get }
+    @_spi(_TecoInternals) static var _valueDescription: String { get }
 }
 
 extension TCDateWrapper {

--- a/Sources/TecoDateHelpers/Protocols/TCDateWrapper.swift
+++ b/Sources/TecoDateHelpers/Protocols/TCDateWrapper.swift
@@ -21,7 +21,7 @@ public protocol TCDateWrapper: Codable, _TecoDateSendable {
     init(wrappedValue: WrappedValue)
 
     @_spi(_TecoInternals) static var _formatter: Formatter { get }
-    @_spi(_TecoInternals) static var _valueDescription: String { get }
+    @_spi(_TecoInternals) static var _valueDescription: StaticString { get }
 }
 
 extension TCDateWrapper {


### PR DESCRIPTION
This PR marks `TCDateWrapper`'s internal requirements with `_TecoInternals` SPI, to prevent users from using it directly. It also enforces `TCDateWrapper._valueDescription` to be a `StaticString` that's known at compile-time.

Companioned by https://github.com/teco-project/teco-code-generators/pull/50.