### PR TITLE
Unblocks `nonmutating set` on `$TCDateWrapper`s

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,8 @@ let package = Package(
             ]),
         .target(name: "TecoPaginationHelpers",
                 dependencies: ["TecoCore"]),
-        .target(name: "TecoDateHelpers"),
+        .target(name: "TecoDateHelpers",
+                dependencies: [.product(name: "NIOConcurrencyHelpers", package: "swift-nio")]),
         .target(name: "INIParser"),
         .target(
             name: "TecoSigner",

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -43,7 +43,8 @@ let package = Package(
             ]),
         .target(name: "TecoPaginationHelpers",
                 dependencies: ["TecoCore"]),
-        .target(name: "TecoDateHelpers"),
+        .target(name: "TecoDateHelpers",
+                dependencies: [.product(name: "NIOConcurrencyHelpers", package: "swift-nio")]),
         .target(name: "INIParser"),
         .target(
             name: "TecoSigner",

--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -43,7 +43,8 @@ let package = Package(
             ]),
         .target(name: "TecoPaginationHelpers",
                 dependencies: ["TecoCore"]),
-        .target(name: "TecoDateHelpers"),
+        .target(name: "TecoDateHelpers",
+                dependencies: [.product(name: "NIOConcurrencyHelpers", package: "swift-nio")]),
         .target(name: "INIParser"),
         .target(
             name: "TecoSigner",

--- a/Sources/TecoDateHelpers/Property Wrappers/TCDateEncoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCDateEncoding.swift
@@ -23,36 +23,36 @@ import class Foundation.DateFormatter
 @propertyWrapper
 public struct TCDateEncoding<WrappedValue: TCDateValue>: Codable {
     public var wrappedValue: WrappedValue {
-        self._dateValue
+        self.date
     }
 
     public var projectedValue: StorageValue {
         get {
-            self._stringValue.withLockedValue {
+            self.string.withLockedValue {
                 $0
             }
         }
         nonmutating set {
-            self._stringValue.withLockedValue {
+            self.string.withLockedValue {
                 $0 = newValue
             }
         }
     }
 
-    private let _dateValue: WrappedValue
+    private let date: WrappedValue
 
-    private let _stringValue: NIOLockedValueBox<StorageValue>
+    private let string: NIOLockedValueBox<StorageValue>
 
     public init(wrappedValue: WrappedValue) {
-        self._dateValue = wrappedValue
-        self._stringValue = NIOLockedValueBox(wrappedValue.encode(formatter: Self._formatter))
+        self.date = wrappedValue
+        self.string = NIOLockedValueBox(wrappedValue.encode(formatter: Self._formatter))
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(StorageValue.self)
-        self._dateValue = try WrappedValue.decode(from: dateString, formatter: Self._formatter, container: container, wrapper: Self.self)
-        self._stringValue = NIOLockedValueBox(dateString)
+        self.date = try WrappedValue.decode(from: dateString, formatter: Self._formatter, container: container, wrapper: Self.self)
+        self.string = NIOLockedValueBox(dateString)
     }
 }
 

--- a/Sources/TecoDateHelpers/Property Wrappers/TCDateEncoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCDateEncoding.swift
@@ -18,6 +18,7 @@ import struct Foundation.Date
 import struct Foundation.Locale
 import struct Foundation.TimeZone
 import class Foundation.DateFormatter
+@_implementationOnly import struct NIOConcurrencyHelpers.NIOLockedValueBox
 
 @propertyWrapper
 public struct TCDateEncoding<WrappedValue: TCDateValue>: Codable {
@@ -27,26 +28,31 @@ public struct TCDateEncoding<WrappedValue: TCDateValue>: Codable {
 
     public var projectedValue: StorageValue {
         get {
-            self._stringValue
+            self._stringValue.withLockedValue {
+                $0
+            }
         }
-        set {
-            self._stringValue = newValue
+        nonmutating set {
+            self._stringValue.withLockedValue {
+                $0 = newValue
+            }
         }
     }
 
-    private var _dateValue: WrappedValue
+    private let _dateValue: WrappedValue
 
-    private var _stringValue: StorageValue
+    private let _stringValue: NIOLockedValueBox<StorageValue>
 
     public init(wrappedValue: WrappedValue) {
         self._dateValue = wrappedValue
-        self._stringValue = wrappedValue.encode(formatter: Self._formatter)
+        self._stringValue = NIOLockedValueBox(wrappedValue.encode(formatter: Self._formatter))
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self._stringValue = try container.decode(StorageValue.self)
-        self._dateValue = try WrappedValue.decode(from: self._stringValue, formatter: Self._formatter, container: container, wrapper: Self.self)
+        let dateString = try container.decode(StorageValue.self)
+        self._dateValue = try WrappedValue.decode(from: dateString, formatter: Self._formatter, container: container, wrapper: Self.self)
+        self._stringValue = NIOLockedValueBox(dateString)
     }
 }
 

--- a/Sources/TecoDateHelpers/Property Wrappers/TCTimestampEncoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCTimestampEncoding.swift
@@ -18,6 +18,7 @@ import struct Foundation.Date
 import struct Foundation.Locale
 import struct Foundation.TimeZone
 import class Foundation.DateFormatter
+@_implementationOnly import struct NIOConcurrencyHelpers.NIOLockedValueBox
 
 @propertyWrapper
 public struct TCTimestampEncoding<WrappedValue: TCDateValue>: Codable {
@@ -27,26 +28,31 @@ public struct TCTimestampEncoding<WrappedValue: TCDateValue>: Codable {
 
     public var projectedValue: StorageValue {
         get {
-            self._stringValue
+            self._stringValue.withLockedValue {
+                $0
+            }
         }
-        set {
-            self._stringValue = newValue
+        nonmutating set {
+            self._stringValue.withLockedValue {
+                $0 = newValue
+            }
         }
     }
 
-    private var _dateValue: WrappedValue
+    private let _dateValue: WrappedValue
 
-    private var _stringValue: StorageValue
+    private let _stringValue: NIOLockedValueBox<StorageValue>
 
     public init(wrappedValue: WrappedValue) {
         self._dateValue = wrappedValue
-        self._stringValue = wrappedValue.encode(formatter: Self._formatter)
+        self._stringValue = NIOLockedValueBox(wrappedValue.encode(formatter: Self._formatter))
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self._stringValue = try container.decode(StorageValue.self)
-        self._dateValue = try WrappedValue.decode(from: self._stringValue, formatter: Self._formatter, container: container, wrapper: Self.self)
+        let dateString = try container.decode(StorageValue.self)
+        self._dateValue = try WrappedValue.decode(from: dateString, formatter: Self._formatter, container: container, wrapper: Self.self)
+        self._stringValue = NIOLockedValueBox(dateString)
     }
 }
 

--- a/Sources/TecoDateHelpers/Property Wrappers/TCTimestampEncoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCTimestampEncoding.swift
@@ -23,36 +23,36 @@ import class Foundation.DateFormatter
 @propertyWrapper
 public struct TCTimestampEncoding<WrappedValue: TCDateValue>: Codable {
     public var wrappedValue: WrappedValue {
-        self._dateValue
+        self.date
     }
 
     public var projectedValue: StorageValue {
         get {
-            self._stringValue.withLockedValue {
+            self.string.withLockedValue {
                 $0
             }
         }
         nonmutating set {
-            self._stringValue.withLockedValue {
+            self.string.withLockedValue {
                 $0 = newValue
             }
         }
     }
 
-    private let _dateValue: WrappedValue
+    private let date: WrappedValue
 
-    private let _stringValue: NIOLockedValueBox<StorageValue>
+    private let string: NIOLockedValueBox<StorageValue>
 
     public init(wrappedValue: WrappedValue) {
-        self._dateValue = wrappedValue
-        self._stringValue = NIOLockedValueBox(wrappedValue.encode(formatter: Self._formatter))
+        self.date = wrappedValue
+        self.string = NIOLockedValueBox(wrappedValue.encode(formatter: Self._formatter))
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(StorageValue.self)
-        self._dateValue = try WrappedValue.decode(from: dateString, formatter: Self._formatter, container: container, wrapper: Self.self)
-        self._stringValue = NIOLockedValueBox(dateString)
+        self.date = try WrappedValue.decode(from: dateString, formatter: Self._formatter, container: container, wrapper: Self.self)
+        self.string = NIOLockedValueBox(dateString)
     }
 }
 

--- a/Sources/TecoDateHelpers/Property Wrappers/TCTimestampISO8601Encoding.swift
+++ b/Sources/TecoDateHelpers/Property Wrappers/TCTimestampISO8601Encoding.swift
@@ -21,36 +21,36 @@ import class Foundation.ISO8601DateFormatter
 @propertyWrapper
 public struct TCTimestampISO8601Encoding<WrappedValue: TCDateValue>: Codable {
     public var wrappedValue: WrappedValue {
-        self._dateValue
+        self.date
     }
 
     public var projectedValue: StorageValue {
         get {
-            self._stringValue.withLockedValue {
+            self.string.withLockedValue {
                 $0
             }
         }
         nonmutating set {
-            self._stringValue.withLockedValue {
+            self.string.withLockedValue {
                 $0 = newValue
             }
         }
     }
 
-    private let _dateValue: WrappedValue
+    private let date: WrappedValue
 
-    private let _stringValue: NIOLockedValueBox<StorageValue>
+    private let string: NIOLockedValueBox<StorageValue>
 
     public init(wrappedValue: WrappedValue) {
-        self._dateValue = wrappedValue
-        self._stringValue = NIOLockedValueBox(wrappedValue.encode(formatter: Self._formatter))
+        self.date = wrappedValue
+        self.string = NIOLockedValueBox(wrappedValue.encode(formatter: Self._formatter))
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(StorageValue.self)
-        self._dateValue = try WrappedValue.decode(from: dateString, formatter: Self._formatter, container: container, wrapper: Self.self)
-        self._stringValue = NIOLockedValueBox(dateString)
+        self.date = try WrappedValue.decode(from: dateString, formatter: Self._formatter, container: container, wrapper: Self.self)
+        self.string = NIOLockedValueBox(dateString)
     }
 }
 

--- a/Sources/TecoDateHelpers/Protocols/TCDateValue.swift
+++ b/Sources/TecoDateHelpers/Protocols/TCDateValue.swift
@@ -27,9 +27,9 @@ extension Foundation.Date: TCDateValue {
         formatter.string(from: self)
     }
 
-    public static func decode<Wrapper: TCDateWrapper>(from stringValue: String, formatter: TCDateFormatter, container: SingleValueDecodingContainer, wrapper: Wrapper.Type = Wrapper.self) throws -> Date {
-        guard let date = formatter.date(from: stringValue) else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid \(wrapper._valueDescription): \(stringValue)")
+    public static func decode<Wrapper: TCDateWrapper>(from string: String, formatter: TCDateFormatter, container: SingleValueDecodingContainer, wrapper: Wrapper.Type = Wrapper.self) throws -> Date {
+        guard let date = formatter.date(from: string) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid \(wrapper._valueDescription): \(string)")
         }
         return date
     }
@@ -45,12 +45,12 @@ extension Swift.Optional: TCDateValue where Wrapped == Foundation.Date {
         }
     }
 
-    public static func decode<Wrapper: TCDateWrapper>(from stringValue: String?, formatter: TCDateFormatter, container: SingleValueDecodingContainer, wrapper: Wrapper.Type = Wrapper.self) throws -> Date? {
-        guard let stringValue = stringValue else {
+    public static func decode<Wrapper: TCDateWrapper>(from string: String?, formatter: TCDateFormatter, container: SingleValueDecodingContainer, wrapper: Wrapper.Type = Wrapper.self) throws -> Date? {
+        guard let string = string else {
             return nil
         }
-        guard let date = formatter.date(from: stringValue) else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid \(wrapper._valueDescription): \(stringValue)")
+        guard let date = formatter.date(from: string) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid \(wrapper._valueDescription): \(string)")
         }
         return date
     }

--- a/Sources/TecoDateHelpers/Protocols/TCDateWrapper.swift
+++ b/Sources/TecoDateHelpers/Protocols/TCDateWrapper.swift
@@ -16,7 +16,7 @@ public protocol TCDateWrapper: Codable, _TecoDateSendable {
     associatedtype Formatter: TCDateFormatter
 
     var wrappedValue: WrappedValue { get }
-    var projectedValue: StorageValue { get }
+    var projectedValue: StorageValue { get nonmutating set }
 
     init(wrappedValue: WrappedValue)
 


### PR DESCRIPTION
This PR uses `NIOLockedValueBox` to allow concurrency-safe mutation on the raw string value through a `TCDateWrapper`. It also simplifies some internal member naming.

Companioned by https://github.com/teco-project/teco-code-generators/pull/50.